### PR TITLE
feat: Add eclipse launcher.

### DIFF
--- a/tools/backend.launch
+++ b/tools/backend.launch
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.launching.localJavaApplication">
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+        <listEntry value="/backend/src/main/java/org/spin/server/AllInOneServices.java"/>
+    </listAttribute>
+    <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+        <listEntry value="1"/>
+    </listAttribute>
+    <mapAttribute key="org.eclipse.debug.core.environmentVariables">
+        <mapEntry key="ADEMPIERE_APPS_TYPE" value="wildfly"/>
+    </mapAttribute>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_ATTR_USE_ARGFILE" value="false"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_EXCLUDE_TEST_CODE" value="true"/>
+    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_CLASSPATH_ONLY_JAR" value="false"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.spin.server.AllInOneServices"/>
+    <stringAttribute key="org.eclipse.jdt.launching.MODULE_NAME" value="backend"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="&quot;resources/standalone.yml&quot;"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="backend"/>
+</launchConfiguration>


### PR DESCRIPTION
Added support for the grpc backend launcher in eclipse.

Using the default connection data from the resources/standalone.yml file.

https://user-images.githubusercontent.com/20288327/167266393-0b451fa0-5170-40b0-b54c-2607722782da.mp4
