### PR TITLE
fix: Lookup reference with UserElement1_ID.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -753,8 +753,9 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 		}
 		//	Process
 		List<MProcess> processList = getProcessActionFromTab(context, tab);
-		if (processList != null && processList.size() > 0) {
-			for (MProcess process : processList) {
+		if(processList != null
+				&& processList.size() > 0) {
+			for(MProcess process : processList) {
 				// get process associated without parameters
 				Process.Builder processBuilder = convertProcess(context, process, false);
 				builder.addProcesses(processBuilder.build());


### PR DESCRIPTION
### Steps to reproduce:
1. Login with GardenAdmin.
2. Open `Financial Report` window.
3. Open browser console and see that the query window is broken.


#### Before this changes:

https://user-images.githubusercontent.com/20288327/169374418-686a4767-308b-4dd3-9711-7ae43de850d3.mp4

#### After this changes:

https://user-images.githubusercontent.com/20288327/169373096-e0741b5b-0b1d-46e6-806b-1b25a215fde2.mp4

#### Additional context:
Resonse:
```json
{
  "code": 500,
  "result": "Cannot read field \"TableName\" because \"info\" is null\nCannot read field \"TableName\" because \"info\" is null"
}
```
