### PR TITLE
fix: Smart Browser empty search.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2838,15 +2838,18 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} else {
 			orderByClause = " ORDER BY " + orderByClause;
 		}
-		//	Count records
+		//	Get page and count
 		int count = RecordUtil.countRecords(parsedSQL, tableName, values);
 		String nexPageToken = null;
 		int pageMultiplier = page == 0? 1: page;
 		if(count > (RecordUtil.getPageSize(request.getPageSize()) * pageMultiplier)) {
 			nexPageToken = RecordUtil.getPagePrefix(request.getClientRequest().getSessionUuid()) + (page + 1);
 		}
+		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
+		int limit = RecordUtil.getPageSize(request.getPageSize());
+		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
 		//	Add Row Number
-		parsedSQL = RecordUtil.getQueryWithLimit(parsedSQL, count, RecordUtil.getPageSize(request.getPageSize()));
+		parsedSQL = RecordUtil.getQueryWithLimit(parsedSQL, limit, offset);
 		//	Add Order By
 		parsedSQL = parsedSQL + orderByClause;
 		//	Return


### PR DESCRIPTION
### Steps to reproduce:
1. Login with GardenAdmin.
2. Open `Process Orders` process.
3. Fill `Document Status` query criteria.


#### Before this changes:
![sb-without-results](https://user-images.githubusercontent.com/20288327/169399417-86a4f99a-87c7-45c9-af67-171499064613.gif)


#### After this changes:
https://user-images.githubusercontent.com/20288327/169396296-18216491-b196-4548-8d93-8836b5499ba1.mp4


#### Additional context:
In the query limit sql used an offset of 2, when it should be zero unless you explicitly send it the page number.