### PR TITLE
fix: Count SQL Aliases and pagination.

### DIFF
--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -302,7 +302,7 @@ public class RecordUtil {
 		}
 		return sql;
 	}
-	
+
 	/**
 	 * Count records
 	 * @param sql
@@ -311,7 +311,28 @@ public class RecordUtil {
 	 * @return
 	 */
 	public static int countRecords(String sql, String tableName, List<Object> parameters) {
-		Matcher matcher = Pattern.compile("\\s+(FROM)\\s+(" + tableName + ")(\\s+)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL).matcher(sql);
+		return countRecords(sql, tableName, null, parameters);
+	}
+	
+	/**
+	 * Count records
+	 * @param sql
+	 * @param tableName
+	 * @param tableNameAlias
+	 * @param parameters
+	 * @return
+	 */
+	public static int countRecords(String sql, String tableName, String tableNameAlias, List<Object> parameters) {
+		String tableWithAliases = tableName;
+		if (!Util.isEmpty(tableNameAlias)) {
+			// tableName tableAlias | tableName AS tableAlias | tableName
+			tableWithAliases = tableName + " " + tableNameAlias + "|" + tableName + " AS " + tableNameAlias; // + "|" + tableName;
+		}
+		Matcher matcher = Pattern.compile(
+				"\\s+(FROM)\\s+(" + tableWithAliases + ")(\\s+)",
+				Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+			)
+			.matcher(sql);
 		int positionFrom = -1;
 		if(matcher.find()) {
 			positionFrom = matcher.start();

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1044,7 +1044,9 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			DB.close(rs, pstmt);
 		}
 		//	Set record counts
-		builder.setRecordCount(recordCount);
+		if (builder.getRecordCount() <= 0) {
+			builder.setRecordCount(recordCount);
+		}
 		//	Return
 		return builder;
 	}
@@ -2830,16 +2832,19 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		String tableNameAlias = parentDefinition.getTableAlias();
 		String tableName = parentDefinition.getAD_Table().getTableName();
 		//	
-		String parsedSQL = MRole.getDefault().addAccessSQL(sql.toString(),
-				tableNameAlias, MRole.SQL_FULLYQUALIFIED,
-				MRole.SQL_RO);
+		String parsedSQL = MRole.getDefault().addAccessSQL(
+			sql.toString(),
+			tableNameAlias,
+			MRole.SQL_FULLYQUALIFIED,
+			MRole.SQL_RO
+		);
 		if(Util.isEmpty(orderByClause)) {
 			orderByClause = "";
 		} else {
 			orderByClause = " ORDER BY " + orderByClause;
 		}
 		//	Get page and count
-		int count = RecordUtil.countRecords(parsedSQL, tableName, values);
+		int count = RecordUtil.countRecords(parsedSQL, tableName, tableNameAlias, values);
 		String nexPageToken = null;
 		int pageMultiplier = page == 0? 1: page;
 		if(count > (RecordUtil.getPageSize(request.getPageSize()) * pageMultiplier)) {
@@ -2856,6 +2861,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		builder = convertBrowserResult(browser, parsedSQL, values);
 		//	Validate page token
 		builder.setNextPageToken(ValueUtil.validateNull(nexPageToken));
+		builder.setRecordCount(count);
 		//	Return
 		return builder;
 	}
@@ -2924,7 +2930,9 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			DB.close(rs, pstmt);
 		}
 		//	Set record counts
-		builder.setRecordCount(recordCount);
+		if (builder.getRecordCount() <= 0) {
+			builder.setRecordCount(recordCount);
+		}
 		//	Return
 		return builder;
 	}


### PR DESCRIPTION
When a Smart Browser has context_attributes, the request for records generates error


```bash
curl 'http://localhost:8080/api/adempiere/user-interface/smart-browser/browser-items?token=be50159c-29c9-4968-9527-cab667fcaa55&language=en' \
  -X POST \
  -H 'Content-Type: application/json' \
  --data-raw '{"uuid":"8aaeea60-fb40-11e8-a479-7a0060f0aa01","filters":[],"context_attributes":[{"key":"C_PaySelection_ID","value":100}]}'
```

#### Output error:

```log
===========> UserInterfaceServiceImplementation.listBrowserItems: org.postgresql.util.PSQLException: ERROR: syntax error at or near ")"
  Position: 113, SQL=SELECT COUNT(*)  FROM C_PaySelectionLine WHERE psl.C_PaySelectionLine_ID=C_PaySelectionLine.C_PaySelectionLine_ID) AS "DisplayColumn_PSL_C_PaySelectionLine_ID", (SELECT NVL(C_PaySelection.DocumentNo,'')||' - '||NVL(CAST (C_PaySelection.TotalAmt AS Text),'') FROM C_PaySelection WHERE psl.C_PaySelection_ID=C_PaySelection.C_PaySelection_ID) AS "DisplayColumn_PSL_C_PaySelection_ID", (SELECT NVL(C_BPartner.Name,'') FROM C_BPartner WHERE psl.C_BPartner_ID=C_BPartner.C_BPartner_ID) AS "DisplayColumn_PSL_C_BPartner_ID", (SELECT NVL(C_BP_BankAccount.A_Name,'')||' - '||NVL(C_BP_BankAccount.AccountNo,'')||' - '||NVL((SELECT NVL(C_Bank.Name,'')||' - '||NVL(C_Bank.RoutingNo,'') FROM C_Bank WHERE C_BP_BankAccount.C_Bank_ID=C_Bank.C_Bank_ID),'') FROM C_BP_BankAccount WHERE psl.C_BP_BankAccount_ID=C_BP_BankAccount.C_BP_BankAccount_ID) AS "DisplayColumn_PSL_C_BP_BankAccount_ID", (SELECT NVL(C_Order.DocumentNo,'')||' - '||NVL(CAST (C_Order.DateOrdered AS Text),'') FROM C_Order WHERE psl.C_Order_ID=C_Order.C_Order_ID) AS "DisplayColumn_PSL_C_Order_ID", (SELECT NVL(C_Invoice.DocumentNo,'')||' - '||NVL(CAST (C_Invoice.DateInvoiced AS Text),'')||' - '||NVL(CAST (C_Invoice.GrandTotal AS Text),'') FROM C_Invoice WHERE psl.C_Invoice_ID=C_Invoice.C_Invoice_ID) AS "DisplayColumn_PSL_C_Invoice_ID", (SELECT NVL((SELECT NVL(HR_Process.DocumentNo,'')||' - '||NVL(HR_Process.Name,'') FROM HR_Process WHERE HR_Movement.HR_Process_ID=HR_Process.HR_Process_ID),'')||' - '||NVL((SELECT NVL(C_BPartner.Name,'') FROM C_BPartner WHERE HR_Movement.C_BPartner_ID=C_BPartner.C_BPartner_ID),'')||' - '||NVL((SELECT NVL(HR_Concept.Value,'')||' - '||NVL(HR_Concept.Name,'') FROM HR_Concept WHERE HR_Movement.HR_Concept_ID=HR_Concept.HR_Concept_ID),'') FROM HR_Movement WHERE psl.HR_Movement_ID=HR_Movement.HR_Movement_ID) AS "DisplayColumn_PSL_HR_Movement_ID", C_Charge_ID_C_Charge.Name AS "DisplayColumn_PSL_C_Charge_ID", PaymentRule_AD_Ref_List.Name AS "DisplayColumn_PSL_PaymentRule", (SELECT NVL(C_ConversionType.Name,'') FROM C_ConversionType WHERE psl.C_ConversionType_ID=C_ConversionType.C_ConversionType_ID) AS "DisplayColumn_PSL_C_ConversionType_ID", (SELECT NVL(CAST (C_Conversion_Rate.C_Conversion_Rate_ID AS Text),'') FROM C_Conversion_Rate WHERE psl.C_Conversion_Rate_ID=C_Conversion_Rate.C_Conversion_Rate_ID) AS "DisplayColumn_PSL_C_Conversion_Rate_ID" FROM  C_PaySelectionLine psl LEFT JOIN C_Charge AS C_Charge_ID_C_Charge ON(C_Charge_ID_C_Charge.C_Charge_ID = psl.C_Charge_ID) LEFT JOIN AD_Ref_List AS PaymentRule_AD_Ref_List ON(PaymentRule_AD_Ref_List.Value = psl.PaymentRule AND PaymentRule_AD_Ref_List.AD_Reference_ID = 195) WHERE NOT EXISTS(SELECT 1 FROM C_PaySelection sps 
		INNER JOIN C_PaySelectionLine spsl ON(spsl.C_PaySelection_ID = sps.C_PaySelection_ID) 
		WHERE spsl.C_PaySelectionLine_Parent_ID = psl.C_PaySelectionLine_ID
		AND sps.DocStatus IN('CO', 'CL'))
AND EXISTS(SELECT 1 FROM C_PaySelection sps 
	WHERE sps.C_PaySelection_ID = psl.C_PaySelection_ID 
	AND sps.DocStatus IN('CO', 'CL') 
	AND sps.C_BankAccount_ID IS NULL)
AND NOT EXISTS(SELECT 1 FROM C_PaySelectionLine rpsl WHERE rpsl.C_PaySelection_ID = 100 AND rpsl.C_PaySelectionLine_Parent_ID = psl.C_PaySelectionLine_ID) AND psl.AD_Client_ID IN(0,11) AND psl.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) AND (psl.C_PaySelectionLine_ID IS NULL OR psl.C_PaySelectionLine_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 427 AND AD_User_ID <> 100 AND IsActive = 'Y' )) [25]
```

