### PR TITLE
feat: Add value to overwrite default value.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -33,6 +33,7 @@ import org.compiere.model.MTable;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Language;
+import org.compiere.util.Util;
 import org.spin.util.ASPUtil;
 
 /**
@@ -120,11 +121,11 @@ public class DictionaryUtil {
 		sql.append("SELECT DISTINCT ");
 		AtomicBoolean co = new AtomicBoolean(false);
 		ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID()).forEach(field -> {
-			if (co.get())
+			if (co.get()) {
 				sql.append(",");
+			}
 			MViewColumn viewColumn = field.getAD_View_Column();
-			if (viewColumn.getColumnSQL() != null
-					&& viewColumn.getColumnSQL().length() > 0) {
+			if (!Util.isEmpty(viewColumn.getColumnSQL(), true)) {
 				sql.append(viewColumn.getColumnSQL());
 				co.set(true);
 			}

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -723,7 +723,12 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 				.setParentTabUuid(ValueUtil.validateNull(parentTabUuid))
 				.setIsChangeLog(table.isChangeLog())
 				.setIsActive(tab.isActive())
-				.addAllContextColumnNames(DictionaryUtil.getContextColumnNames(Optional.ofNullable(whereClause.toString()).orElse("") + Optional.ofNullable(tab.getOrderByClause()).orElse("")));
+				.addAllContextColumnNames(
+					DictionaryUtil.getContextColumnNames(
+						Optional.ofNullable(whereClause.toString()).orElse("")
+						+ Optional.ofNullable(tab.getOrderByClause()).orElse("")
+					)
+				);
 		//	For link
 		if(contextInfoId > 0) {
 			ContextInfo.Builder contextInfoBuilder = convertContextInfo(context, contextInfoId);
@@ -918,7 +923,13 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 				.setIsSelectedByDefault(browser.isSelectedByDefault())
 				.setIsShowTotal(browser.isShowTotal())
 				.setIsUpdateable(browser.isUpdateable())
-				.addAllContextColumnNames(DictionaryUtil.getContextColumnNames(Optional.ofNullable(query).orElse("") + Optional.ofNullable(browser.getWhereClause()).orElse("") + Optional.ofNullable(orderByClause).orElse("")));
+				.addAllContextColumnNames(
+					DictionaryUtil.getContextColumnNames(
+						Optional.ofNullable(query).orElse("")
+						+ Optional.ofNullable(browser.getWhereClause()).orElse("")
+						+ Optional.ofNullable(orderByClause).orElse("")
+					)
+				);
 		//	Set View UUID
 		if(browser.getAD_View_ID() > 0) {
 			builder.setViewUuid(ValueUtil.validateNull(browser.getAD_View().getUUID()));

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2167,8 +2167,16 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} else {
 			throw new AdempiereException("@AD_Reference_ID@ / @AD_Column_ID@ / @AD_Table_ID@ / @AD_Process_Para_ID@ / @IsMandatory@");
 		}
+		
+		// overwrite default value with user value request
+		if (Optional.ofNullable(request.getValue()).isPresent()
+			&& !Util.isEmpty(request.getValue().getStringValue())) {
+			defaultValue = request.getValue().getStringValue();
+		}
+		
 		//	Validate SQL
-		return getDefaultKeyAndValue(request.getContextAttributesList(), defaultValue, referenceId, referenceValueId, columnName, validationRuleId);
+		DefaultValue.Builder builder = getDefaultKeyAndValue(request.getContextAttributesList(), defaultValue, referenceId, referenceValueId, columnName, validationRuleId);
+		return builder;
 	}
 	
 	

--- a/src/main/proto/business.proto
+++ b/src/main/proto/business.proto
@@ -378,7 +378,7 @@ message GetDefaultValueRequest {
 	string browse_field_uuid = 4;
 	string column_uuid = 5;
 	repeated KeyValue context_attributes = 6;
-	
+	Value value = 7;
 }
 
 // Default Value Response


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature


#### Steps to reproduce

1. Expand `Open Item` menu.
2. Open `Generate Payment Selection (From Invoice)`

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/171664982-fc60601b-e071-49bc-afac-e27ea06972d6.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/171664987-528f88f5-7548-406a-ac84-7616ff511702.mp4

#### Expected behavior
In the backend it was looking for the default value of the `Bank Account` field, but since it was not in the dictionary definition it returned empty values.

In the context of the session we have the value in the `Bank Account` field, so it should be automatically set, overwriting the possible default value in case of having it.

Also, when changing the value of this field, all the fields that are dependent on it, such as the `Currency` and `Current Balance` fields, must change or clear their values.

#### Other relevant information
- Your OS: Linux Mint 20.3 x64.
- Web Browser: Mozilla Firefox 99.0
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/11 https://github.com/solop-develop/frontend-core/issues/67 https://github.com/solop-develop/frontend-core/issues/98 https://github.com/solop-develop/frontend-core/issues/140


