### PR TITLE
fix: Filter tab entities with link column.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -796,7 +796,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 		List<MProcessPara> processParametersList = ASPUtil.getInstance(context).getProcessParameters(process.getAD_Process_ID());
 		builder.setIsHasParameters(processParametersList.size() > 0);
 		if(withParams) {
-			for (MProcessPara parameter : processParametersList) {
+			for(MProcessPara parameter : processParametersList) {
 				Field.Builder fieldBuilder = convertProcessParameter(context, parameter);
 				builder.addParameters(fieldBuilder.build());
 			}
@@ -855,7 +855,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			builder.setProcess(processBuilder.build());
 		}
 		//	For parameters
-		if (withFields) {
+		if(withFields) {
 			for(MBrowseField field : ASPUtil.getInstance(context).getBrowseFields(browser.getAD_Browse_ID())) {
 				Field.Builder fieldBuilder = convertBrowseField(context, field);
 				builder.addFields(fieldBuilder.build());

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -792,11 +792,8 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			}
 		}
 		//	For parameters
-
-		List<MProcessPara> processParametersList = ASPUtil.getInstance(context).getProcessParameters(process.getAD_Process_ID());
-		builder.setIsHasParameters(processParametersList.size() > 0);
 		if(withParams) {
-			for(MProcessPara parameter : processParametersList) {
+			for(MProcessPara parameter : ASPUtil.getInstance(context).getProcessParameters(process.getAD_Process_ID())) {
 				Field.Builder fieldBuilder = convertProcessParameter(context, parameter);
 				builder.addParameters(fieldBuilder.build());
 			}

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1014,9 +1014,6 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 			throw new AdempiereException("@AD_Tab_ID@ @WhereClause@ @Unparseable@");
 		}
 		Criteria criteria = request.getFilters();
-		if (tab.getAD_Column_ID() > 0) {
-			
-		}
 		StringBuffer whereClause = new StringBuffer(parsedWhereClause);
 		List<Object> params = new ArrayList<>();
 		//	For dynamic condition
@@ -3310,7 +3307,6 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		if(keyValue == null) {
 			return builder;
 		}
-		System.out.println(ValueUtil.validateNull(uuidValue));
 		builder.setUuid(ValueUtil.validateNull(uuidValue));
 		
 		if(keyValue instanceof Integer) {

--- a/src/main/proto/dictionary.proto
+++ b/src/main/proto/dictionary.proto
@@ -271,7 +271,7 @@ message Process {
 	string browser_uuid = 14;
 	string form_uuid = 15;
 	string workflow_uuid = 16;
-	bool is_has_parameters = 17;
+
 }
 
 // Form

--- a/src/main/proto/dictionary.proto
+++ b/src/main/proto/dictionary.proto
@@ -271,6 +271,7 @@ message Process {
 	string browser_uuid = 14;
 	string form_uuid = 15;
 	string workflow_uuid = 16;
+	bool is_has_parameters = 17;
 }
 
 // Form

--- a/src/main/proto/dictionary.proto
+++ b/src/main/proto/dictionary.proto
@@ -271,7 +271,6 @@ message Process {
 	string browser_uuid = 14;
 	string form_uuid = 15;
 	string workflow_uuid = 16;
-
 }
 
 // Form


### PR DESCRIPTION
When opening a window with multiple tabs, in this case `View` and querying the data of tabs such as child tabs that do not have closing where but with link column or with parent column, it does not perform the records filter correctly.

#### Steps to reproduce:

1. Open `View` window.
2. Show grid records in `View Definition` tab.
3. Change record in `View` tab.


#### Before this changes:

https://user-images.githubusercontent.com/20288327/172665121-2f08589a-53ef-4b01-97e9-0c1fe09b35d6.mp4



#### After this changes:

https://user-images.githubusercontent.com/20288327/172664675-82438fb5-d336-4305-a67e-d4a7ff23d3fc.mp4


#### Additional context

http://localhost:8080/api/adempiere/user-interface/window/entities?window_uuid=a521b0ee-fb40-11e8-a479-7a0060f0aa01&tab_uuid=a4a2b050-fb40-11e8-a479-7a0060f0aa01&context_attributes[]={%22value%22:50043,%22key%22:%22AD_View_ID%22}&search_value=&page_size=15&token=1d0caa00-85f0-4e00-ba31-78cc45ea91d2&language=es




