### PR TITLE
fix: Zoom Window of Smart Browser selection.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -155,9 +155,11 @@ public class DictionaryUtil {
 						&& parentTab.getTabLevel() < tabLevel
 						&& !parentTab.isTranslationTab();
 				})
-				.sorted(Comparator.comparing(MTab::getSeqNo)
-				.thenComparing(MTab::getTabLevel)
-				.reversed())
+				.sorted(
+					Comparator.comparing(MTab::getSeqNo)
+						.thenComparing(MTab::getTabLevel)
+						.reversed()
+				)
 				.collect(Collectors.toList());
 			//	Validate direct child
 			if(tabList.size() == 0) {
@@ -224,11 +226,11 @@ public class DictionaryUtil {
 			}
 		}
 
+		StringBuffer where = new StringBuffer(ValueUtil.validateNull(tab.getWhereClause()));
 		//	Set where clause for tab
-		if(!Util.isEmpty(tab.getWhereClause(), true)) {
-			whereClause.append(" AND ").append("(").append(tab.getWhereClause()).append(")");
-		} else {
-			whereClause.append(ValueUtil.validateNull(tab.getWhereClause()));
+		if(!Util.isEmpty(whereClause.toString(), true)) {
+			where.append(" AND ").append("(").append(whereClause).append(")");
+			return where.toString();
 		}
 		return whereClause.toString();
 	}

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1009,8 +1009,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		String where = DictionaryUtil.getSQLWhereClauseFromTab(context, tab, null);
 		String parsedWhereClause = Env.parseContext(context, windowNo, where, false);
 		
-		if(Util.isEmpty(where)
-				&& !Util.isEmpty(parsedWhereClause)) {
+		if(Util.isEmpty(parsedWhereClause)
+				&& !Util.isEmpty(where)) {
 			throw new AdempiereException("@AD_Tab_ID@ @WhereClause@ @Unparseable@");
 		}
 		Criteria criteria = request.getFilters();
@@ -1018,8 +1018,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		List<Object> params = new ArrayList<>();
 		//	For dynamic condition
 		String dynamicWhere = ValueUtil.getWhereClauseFromCriteria(criteria, tableName, params);
-		if(!Util.isEmpty(dynamicWhere)) {
-			if(whereClause.length() > 0) {
+		if(!Util.isEmpty(dynamicWhere, true)) {
+			if(!Util.isEmpty(whereClause.toString(), true)) {
 				whereClause.append(" AND ");
 			}
 			//	Add
@@ -1044,7 +1044,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		ListTabEntitiesResponse.Builder builder = ListTabEntitiesResponse.newBuilder();
 		//	
 		StringBuilder sql = new StringBuilder(DictionaryUtil.getQueryWithReferencesFromTab(tab));
-		if (whereClause.length() > 0) {
+		if (!Util.isEmpty(whereClause.toString(), true)) {
 			sql.append(" WHERE ").append(whereClause); // includes first AND
 		}
 		//	


### PR DESCRIPTION
When zoom windows associated on smart browser selection:


```json
{
  "code": 500,
  "result": "org.postgresql.util.PSQLException: ERROR: syntax error at or near \"AND\"\n  Position: 5262, SQL=SELECT COUNT(*)  FROM C_Order AS C_Order LEFT JOIN C_DocType AS C_DocTypeTarget_ID_C_DocType ON(C_DocTypeTarget_ID_C_DocType.C_DocType_ID = C_Order.C_DocTypeTarget_ID) LEFT JOIN C_DocType_Trl AS C_DocTypeTarget_ID_C_DocType_Trl ON(C_DocTypeTarget_ID_C_DocType_Trl.C_DocType_ID = C_DocTypeTarget_ID_C_DocType.C_DocType_ID AND C_DocTypeTarget_ID_C_DocType_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS Bill_BPartner_ID_C_BPartner ON(Bill_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.Bill_BPartner_ID) LEFT JOIN C_BPartner_Location AS Bill_Location_ID_C_BPartner_Location ON(Bill_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.Bill_Location_ID) LEFT JOIN AD_User AS Bill_User_ID_AD_User ON(Bill_User_ID_AD_User.AD_User_ID = C_Order.Bill_User_ID) LEFT JOIN AD_Ref_List AS DeliveryRule_AD_Ref_List ON(DeliveryRule_AD_Ref_List.Value = C_Order.DeliveryRule AND DeliveryRule_AD_Ref_List.AD_Reference_ID = 151) LEFT JOIN AD_Ref_List_Trl AS DeliveryRule_AD_Ref_List_Trl ON(DeliveryRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS PriorityRule_AD_Ref_List ON(PriorityRule_AD_Ref_List.Value = C_Order.PriorityRule AND PriorityRule_AD_Ref_List.AD_Reference_ID = 154) LEFT JOIN AD_Ref_List_Trl AS PriorityRule_AD_Ref_List_Trl ON(PriorityRule_AD_Ref_List_Trl.AD_Ref_List_ID = PriorityRule_AD_Ref_List.AD_Ref_List_ID AND PriorityRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN C_BPartner AS DropShip_BPartner_ID_C_BPartner ON(DropShip_BPartner_ID_C_BPartner.C_BPartner_ID = C_Order.DropShip_BPartner_ID) LEFT JOIN C_BPartner_Location AS DropShip_Location_ID_C_BPartner_Location ON(DropShip_Location_ID_C_BPartner_Location.C_BPartner_Location_ID = C_Order.DropShip_Location_ID) LEFT JOIN AD_User AS DropShip_User_ID_AD_User ON(DropShip_User_ID_AD_User.AD_User_ID = C_Order.DropShip_User_ID) LEFT JOIN AD_Ref_List AS DeliveryViaRule_AD_Ref_List ON(DeliveryViaRule_AD_Ref_List.Value = C_Order.DeliveryViaRule AND DeliveryViaRule_AD_Ref_List.AD_Reference_ID = 152) LEFT JOIN AD_Ref_List_Trl AS DeliveryViaRule_AD_Ref_List_Trl ON(DeliveryViaRule_AD_Ref_List_Trl.AD_Ref_List_ID = DeliveryViaRule_AD_Ref_List.AD_Ref_List_ID AND DeliveryViaRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS FreightCostRule_AD_Ref_List ON(FreightCostRule_AD_Ref_List.Value = C_Order.FreightCostRule AND FreightCostRule_AD_Ref_List.AD_Reference_ID = 153) LEFT JOIN AD_Ref_List_Trl AS FreightCostRule_AD_Ref_List_Trl ON(FreightCostRule_AD_Ref_List_Trl.AD_Ref_List_ID = FreightCostRule_AD_Ref_List.AD_Ref_List_ID AND FreightCostRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS InvoiceRule_AD_Ref_List ON(InvoiceRule_AD_Ref_List.Value = C_Order.InvoiceRule AND InvoiceRule_AD_Ref_List.AD_Reference_ID = 150) LEFT JOIN AD_Ref_List_Trl AS InvoiceRule_AD_Ref_List_Trl ON(InvoiceRule_AD_Ref_List_Trl.AD_Ref_List_ID = InvoiceRule_AD_Ref_List.AD_Ref_List_ID AND InvoiceRule_AD_Ref_List_Trl.AD_Language = 'es_MX') LEFT JOIN AD_User AS SalesRep_ID_AD_User ON(SalesRep_ID_AD_User.AD_User_ID = C_Order.SalesRep_ID) LEFT JOIN C_Charge AS C_Charge_ID_C_Charge ON(C_Charge_ID_C_Charge.C_Charge_ID = C_Order.C_Charge_ID) LEFT JOIN C_Charge_Trl AS C_Charge_ID_C_Charge_Trl ON(C_Charge_ID_C_Charge_Trl.C_Charge_ID = C_Charge_ID_C_Charge.C_Charge_ID AND C_Charge_ID_C_Charge_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Org AS AD_OrgTrx_ID_AD_Org ON(AD_OrgTrx_ID_AD_Org.AD_Org_ID = C_Order.AD_OrgTrx_ID) LEFT JOIN C_ElementValue AS User1_ID_C_ElementValue ON(User1_ID_C_ElementValue.C_ElementValue_ID = C_Order.User1_ID) LEFT JOIN C_ElementValue_Trl AS User1_ID_C_ElementValue_Trl ON(User1_ID_C_ElementValue_Trl.C_ElementValue_ID = User1_ID_C_ElementValue.C_ElementValue_ID AND User1_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User2_ID_C_ElementValue ON(User2_ID_C_ElementValue.C_ElementValue_ID = C_Order.User2_ID) LEFT JOIN C_ElementValue_Trl AS User2_ID_C_ElementValue_Trl ON(User2_ID_C_ElementValue_Trl.C_ElementValue_ID = User2_ID_C_ElementValue.C_ElementValue_ID AND User2_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN C_ElementValue AS User3_ID_C_ElementValue ON(User3_ID_C_ElementValue.C_ElementValue_ID = C_Order.User3_ID) LEFT JOIN C_ElementValue_Trl AS User3_ID_C_ElementValue_Trl ON(User3_ID_C_ElementValue_Trl.C_ElementValue_ID = User3_ID_C_ElementValue.C_ElementValue_ID AND User3_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN W_Basket AS W_Basket_ID_W_Basket ON(W_Basket_ID_W_Basket.W_Basket_ID = C_Order.W_Basket_ID) LEFT JOIN C_ElementValue AS User4_ID_C_ElementValue ON(User4_ID_C_ElementValue.C_ElementValue_ID = C_Order.User4_ID) LEFT JOIN C_ElementValue_Trl AS User4_ID_C_ElementValue_Trl ON(User4_ID_C_ElementValue_Trl.C_ElementValue_ID = User4_ID_C_ElementValue.C_ElementValue_ID AND User4_ID_C_ElementValue_Trl.AD_Language = 'es_MX') LEFT JOIN AD_Ref_List AS DocStatus_AD_Ref_List ON(DocStatus_AD_Ref_List.Value = C_Order.DocStatus AND DocStatus_AD_Ref_List.AD_Reference_ID = 131) LEFT JOIN AD_Ref_List_Trl AS DocStatus_AD_Ref_List_Trl ON(DocStatus_AD_Ref_List_Trl.AD_Ref_List_ID = DocStatus_AD_Ref_List.AD_Ref_List_ID AND DocStatus_AD_Ref_List_Trl.AD_Language = 'es_MX') WHERE  AND (C_Order.IsSOTrx='Y' AND EXISTS(SELECT 1 FROM C_DocType dt WHERE dt.C_DocType_ID = C_Order.C_DocTypeTarget_ID AND dt.DocBaseType = 'SOO' AND (dt.DocSubTypeSO IS NULL OR dt.DocSubTypeSO <> 'RM'))) AND (C_Order.C_Order_ID IN (?, ?)) AND C_Order.AD_Client_ID IN(0,11) AND C_Order.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) AND (C_Order.C_Order_ID IS NULL OR C_Order.C_Order_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 259 AND AD_User_ID <> 101 AND IsActive = 'Y' ))"
}
```

There is an `AND` after a `WHERE` with the first condition being.

#### Steps to reproduce:

1. Open `Process Orders` smart browser.
2. Search records.
3. Select two or more records.
4. Expand actions menu.
5. Zoom window associated `Sales Orders`.


```bash
curl --location -g --request GET 'http://localhost:8080/api/adempiere/user-interface/window/entities?window_uuid=a52203d2-fb40-11e8-a479-7a0060f0aa01&tab_uuid=a49ff9be-fb40-11e8-a479-7a0060f0aa01&search_value=&page_size=15&language=es&token=06ccb9c1-8089-4b62-9bfc-07734a23bab5&filters[]=%7B%22column_name%22:%22C_Order_ID%22,%22operator%22:%22IN%22,%22values%22:[101,108]%7D'
```

#### Expected behavior:
The selected records are expected to be set as search filters in the window, so that only the selected records from which they were zoomed in are visible.


```json
{
    "code": 200,
    "result": {
        "record_count": 2,
        "next_page_token": "",
        "records": [
          ...
        ]
    }
}
```

#### Additional context:
resolve https://github.com/solop-develop/frontend-core/issues/164

