### PR TITLE
fix: Get entites with where clause.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -228,11 +228,15 @@ public class DictionaryUtil {
 
 		StringBuffer where = new StringBuffer(ValueUtil.validateNull(tab.getWhereClause()));
 		//	Set where clause for tab
-		if(!Util.isEmpty(whereClause.toString(), true)) {
-			where.append(" AND ").append("(").append(whereClause).append(")");
+		if (Util.isEmpty(where.toString(), true)) {
+			return whereClause.toString();
+		}
+		if (Util.isEmpty(whereClause.toString(), true)) {
 			return where.toString();
 		}
-		return whereClause.toString();
+		// joined tab where clause with generated where clause
+		where.append(" AND ").append("(").append(whereClause).append(")");
+		return where.toString();
 	}
 	
 	/**


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `Business Partner` window and set record.
2. Change multi records in `Customer Accounting` tab.
3. See without records.
4. Select to `Location` tab and change to multi record.
3. See without records.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/174104804-ea8b1277-e789-42ba-895d-363833e12bcf.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/174104824-118aa9bc-a6b1-4df9-b2ba-ae54273ee675.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context

Request:
```bash
curl 'http://localhost:8085/api/adempiere/user-interface/window/entities?window_uuid=a520de12-fb40-11e8-a479-7a0060f0aa01&tab_uuid=a4a06ffc-fb40-11e8-a479-7a0060f0aa01&context_attributes[]=%7B%22value%22:121,%22key%22:%22C_BPartner_ID%22%7D&search_value=&page_size=15&token=26bf0542-2a72-4808-8974-9d4927bf077a&language=en'
```
Response:
```json
{
  "code": 500,
  "result": "org.postgresql.util.PSQLException: ERROR: syntax error at or near \"AND\"\n  Position: 71, SQL=SELECT COUNT(*)  FROM C_BPartner_Location AS C_BPartner_Location WHERE  AND (C_BPartner_Location.C_BPartner_ID = 121) AND C_BPartner_Location.AD_Client_ID IN(0,11) AND C_BPartner_Location.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) AND (C_BPartner_Location.C_BPartner_Location_ID IS NULL OR C_BPartner_Location.C_BPartner_Location_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 293 AND AD_User_ID <> 100 AND IsActive = 'Y' ))\norg.postgresql.util.PSQLException: ERROR: syntax error at or near \"AND\"\n  Position: 71, SQL=SELECT COUNT(*)  FROM C_BPartner_Location AS C_BPartner_Location WHERE  AND (C_BPartner_Location.C_BPartner_ID = 121) AND C_BPartner_Location.AD_Client_ID IN(0,11) AND C_BPartner_Location.AD_Org_ID IN(0,11,12,50000,50002,50001,50004,50006,50005,50007) AND (C_BPartner_Location.C_BPartner_Location_ID IS NULL OR C_BPartner_Location.C_BPartner_Location_ID NOT IN ( SELECT Record_ID FROM AD_Private_Access WHERE AD_Table_ID = 293 AND AD_User_ID <> 100 AND IsActive = 'Y' ))"
}
```

fixes https://github.com/solop-develop/frontend-core/issues/140

