### PR TITLE
feat: Run process add record as parameter.

### DIFF
--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -249,6 +249,8 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 			}
 		}
 		PO entity = null;
+		List<KeyValue> parametersList = new ArrayList<KeyValue>();
+		parametersList.addAll(request.getParametersList());
 		if((recordId != 0
 				|| !Util.isEmpty(request.getUuid()))
 				&& !Util.isEmpty(request.getTableName())) {
@@ -260,7 +262,18 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 			if(entity != null) {
 				recordId = entity.get_ID();
 			}
+
+			// Add record as parameter
+			Value.Builder value = Value.newBuilder()
+				.setValueType(Value.ValueType.INTEGER)
+				.setIntValue(recordId);
+			KeyValue.Builder recordParameter = KeyValue.newBuilder()
+				.setKey(request.getTableName() + "_ID")
+				.setValue(value);
+			// set as first position
+			parametersList.add(0, recordParameter.build());
 		}
+
 		//	Add to recent Item
 		addToRecentItem(MMenu.ACTION_Process, process.getAD_Process_ID());
 		//	Call process builder
@@ -291,7 +304,7 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 		String documentAction = null;
 		//	Parameters
 		if(request.getParametersCount() > 0) {
-			for(KeyValue parameter : request.getParametersList()) {
+			for(KeyValue parameter : parametersList) {
 				Object value = ValueUtil.getObjectFromValue(parameter.getValue());
 				if(value != null) {
 					builder.withParameter(parameter.getKey(), value);


### PR DESCRIPTION
Add record as parameter from which process or report was executed


https://user-images.githubusercontent.com/20288327/174331971-eb4e5229-2a4c-4f0e-aa55-7245958e3316.mp4

#### Steps to reproduce
1. Login with GardenAdmin.
2. Open `Business Partner` window.
3. Select `Customer` tab.
4. Click in `Open Items` field button.
5. See key column (Business Partner) in report.

#### Additional context
cURL request

```shell
curl 'http://localhost:8085/api/adempiere/common/api/process?token=26bf0542-2a72-4808-8974-9d4927bf077a&language=en' \
  -X POST \
  -H 'Content-Type: application/json' \
  --data-raw '{"process_uuid":"a42cfc20-fb40-11e8-a479-7a0060f0aa01","table_name":"C_BPartner","uuid":"c3cfeb5f-1b2f-4f4b-a16c-d9cda23f59e1","report_type":"pdf","parameters":[{"key":"DaysDue","value":-99999},{"key":"DaysDue_To","value":99999}]}'
```
