### PR TITLE
fix: Set and get correct page number of records.

### DIFF
--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -63,12 +63,15 @@ public class RecordUtil {
 	 * @return
 	 */
 	public static int getPageNumber(String sessionUuid, String pageToken) {
-		int page = 0;
+		int page = 1;
 		String pagePrefix = getPagePrefix(sessionUuid);
 		if(!Util.isEmpty(pageToken)) {
 			if(pageToken.startsWith(pagePrefix)) {
 				try {
 					page = Integer.parseInt(pageToken.replace(pagePrefix, ""));
+					if (page < 1) {
+						page = 1;
+					}
 				} catch (Exception e) {
 					//	
 				}

--- a/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
@@ -256,7 +256,7 @@ public class AccessServiceImplementation extends SecurityImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_AD_Role.Table_Name, 
 				"EXISTS(SELECT 1 FROM AD_User_Roles ur WHERE ur.AD_Role_ID = AD_Role.AD_Role_ID AND ur.AD_User_ID = ?)", null)
 				.setParameters(session.getCreatedBy());

--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -646,7 +646,7 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int count = 0;
 		ListEntitiesResponse.Builder builder = ListEntitiesResponse.newBuilder();
 		//	

--- a/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
+++ b/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
@@ -315,7 +315,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		ListBusinessPartnersResponse.Builder builder = ListBusinessPartnersResponse.newBuilder();
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get business partner list
 		//	Dynamic where clause
@@ -764,7 +764,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		//	Get page and count
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_AD_Org.Table_Name, whereClause, null)
 				.setParameters(parameters)
@@ -798,7 +798,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		//	Get page and count
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
 		int id = request.getOrganizationId();
 		if(id <= 0) {

--- a/src/main/java/org/spin/grpc/service/LogsServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/LogsServiceImplementation.java
@@ -346,7 +346,7 @@ public class LogsServiceImplementation extends LogsImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_AD_WF_Process.Table_Name, whereClause.toString(), null)
 				.setParameters(parameters);
 		int count = query.count();
@@ -405,7 +405,7 @@ public class LogsServiceImplementation extends LogsImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_AD_ChangeLog.Table_Name, whereClause.toString(), null)
 				.setParameters(parameters);
 		int count = query.count();
@@ -867,7 +867,7 @@ public class LogsServiceImplementation extends LogsImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int id = request.getId();
 		if(id <= 0) {
 			id = RecordUtil.getIdFromUuid(I_CM_Chat.Table_Name, request.getUuid(), null);
@@ -929,7 +929,7 @@ public class LogsServiceImplementation extends LogsImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_CM_Chat.Table_Name, whereClause.toString(), null)
 				.setParameters(parameters);
 		int count = query.count();

--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -1212,7 +1212,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 			String nexPageToken = null;
 			int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 			int limit = RecordUtil.getPageSize(request.getPageSize());
-			int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+			int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 			//	Dynamic where clause
 			//	Get Product list
 			Query query = new Query(Env.getCtx(), I_C_BP_BankAccount.Table_Name, I_C_BP_BankAccount.COLUMNNAME_C_BPartner_ID + " = ?", null)
@@ -1648,7 +1648,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
 		//	
 		StringBuffer whereClause = new StringBuffer();
@@ -1798,7 +1798,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int count = 0;
 		try {
 			//	Get Bank statement
@@ -2183,7 +2183,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int shipmentId = RecordUtil.getIdFromUuid(I_M_InOut.Table_Name, request.getShipmentUuid(), null);
 		//	Get Product list
 		Query query = new Query(Env.getCtx(), I_M_InOutLine.Table_Name, I_M_InOutLine.COLUMNNAME_M_InOut_ID + " = ?", null)
@@ -2225,7 +2225,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		List<Object> parameters = new ArrayList<Object>();
 		StringBuffer whereClause = new StringBuffer("IsPaid = 'N' AND Processed = 'N'");
 		if(!Util.isEmpty(request.getOrderUuid())) {
@@ -2921,7 +2921,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Aisle Seller
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
 		//	Get Product list
@@ -2971,7 +2971,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		//	Aisle Seller
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
@@ -3028,7 +3028,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		//	Aisle Seller
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
@@ -3092,7 +3092,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		//	Aisle Seller
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
@@ -3137,7 +3137,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		String whereClause = "EXISTS(SELECT 1 FROM C_Conversion_Rate cr "
 				+ "WHERE (cr.C_Currency_ID = C_Currency.C_Currency_ID  OR cr.C_Currency_ID_To = C_Currency.C_Currency_ID) "
@@ -3709,7 +3709,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		int posId = RecordUtil.getIdFromUuid(I_C_POS.Table_Name, request.getPosUuid(), null);
 		int salesRepresentativeId = RecordUtil.getIdFromUuid(I_AD_User.Table_Name, request.getSalesRepresentativeUuid(), null);
@@ -3830,7 +3830,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters
@@ -3897,7 +3897,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		StringBuffer whereClause = new StringBuffer(I_C_OrderLine.COLUMNNAME_C_Order_ID + " = ?");
 		List<Object> parameters = new ArrayList<>();
 		parameters.add(orderId);
@@ -4756,7 +4756,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get POS List
 		boolean isAppliedNewFeaturesPOS = M_Element.get(Env.getCtx(), "IsSharedPOS") != null && M_Element.get(Env.getCtx(), "IsAllowsAllocateSeller") != null;
 		StringBuffer whereClause = new StringBuffer("SalesRep_ID = ? OR EXISTS(SELECT 1 FROM AD_User u WHERE u.AD_User_ID = ? AND IsPOSManager = 'Y')");
@@ -5572,7 +5572,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Dynamic where clause
 		StringBuffer whereClause = new StringBuffer();
 		//	Parameters

--- a/src/main/java/org/spin/grpc/service/UpdateImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UpdateImplementation.java
@@ -141,7 +141,7 @@ public class UpdateImplementation extends UpdateCenterImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber("page-token", request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get POS List
 		StringBuffer whereClause = new StringBuffer("AD_Migration_ID = ?");
 		List<Object> parameters = new ArrayList<>();
@@ -230,7 +230,7 @@ public class UpdateImplementation extends UpdateCenterImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber("page-token", request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get POS List
 		StringBuffer whereClause = new StringBuffer("EntityType = ?");
 		List<Object> parameters = new ArrayList<>();
@@ -303,7 +303,7 @@ public class UpdateImplementation extends UpdateCenterImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber("page-token", request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get POS List
 		String whereClause = null;
 		List<Object> parameters = new ArrayList<>();

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1039,7 +1039,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int count = 0;
 		ListTabEntitiesResponse.Builder builder = ListTabEntitiesResponse.newBuilder();
 		//	
@@ -2665,7 +2665,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		int count = 0;
 		//	Count records
 		count = RecordUtil.countRecords(sql, reference.TableName, parameters);
@@ -2962,7 +2962,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		}
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Add Row Number
 		parsedSQL = RecordUtil.getQueryWithLimit(parsedSQL, limit, offset);
 		//	Add Order By

--- a/src/main/java/org/spin/grpc/service/WebStoreServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WebStoreServiceImplementation.java
@@ -1373,7 +1373,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		//	Get Orders list
 		Query query = new Query(Env.getCtx(), I_C_Order.Table_Name, "EXISTS(SELECT 1 FROM W_Basket b WHERE b.W_Basket_ID = C_Order.W_Basket_ID AND b.AD_User_ID = ?)", null)
 				.setParameters(Env.getAD_User_ID(Env.getCtx()))
@@ -1418,7 +1418,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		StringBuffer whereClause = new StringBuffer(I_M_Product.COLUMNNAME_SKU + " IN(");
 		whereClause.append(")");
 		Query query = new Query(Env.getCtx(), I_W_DeliveryViaRuleAllocation.Table_Name, I_W_DeliveryViaRuleAllocation.COLUMNNAME_W_Store_ID + " = ?", null)
@@ -1594,7 +1594,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_C_PaymentMethod.Table_Name, "EXISTS(SELECT 1 FROM C_PaymentMethodAllocation a "
 				+ "WHERE a.C_PaymentMethod_ID = C_PaymentMethod.C_PaymentMethod_ID "
 				+ "AND a.W_Store_ID = ?)" , null)
@@ -2336,7 +2336,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		StringBuffer whereClause = new StringBuffer(I_M_Product.COLUMNNAME_SKU + " IN(");
 		AtomicBoolean first = new AtomicBoolean(true);
 		List<Object> parameters = new ArrayList<>();
@@ -2394,7 +2394,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		StringBuffer whereClause = new StringBuffer(I_M_Product.COLUMNNAME_SKU + " IN(");
 		AtomicBoolean first = new AtomicBoolean(true);
 		List<Object> parameters = new ArrayList<>();
@@ -2628,7 +2628,7 @@ public class WebStoreServiceImplementation extends WebStoreImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_M_Storage.Table_Name, 
 				I_M_Storage.COLUMNNAME_M_Product_ID + " = ? "
 						+ "AND " + I_M_Storage.COLUMNNAME_QtyOnHand + " > 0", null)

--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -184,7 +184,7 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(context, I_AD_WF_Activity.Table_Name, whereClause, null)
 				.setParameters(userId, userId, userId, userId);
 		int count = query.count();
@@ -428,7 +428,7 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = pageNumber * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(context, I_AD_Workflow.Table_Name, whereClause.toString(), null)
 				.setParameters(parameters);
 		int count = query.count();


### PR DESCRIPTION
Currently in the frontend the first page 1 is handled, however in the backend the first page is 0.

Provisionally it was solved in the frontend by subtracting -1 from the current page, but when new implementations were added, and more functionalities where the page number was involved, inconsistencies were created.

Now in both, backend and frontend, both handle as first page number 1.




