### PR TITLE
fix: SmartBrowser delete entity without table.

### DIFF
--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -543,6 +543,10 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 	 */
 	private Empty.Builder deleteEntity(Properties context, DeleteEntityRequest request) {
 		Trx.run(transactionName -> {
+			if(Util.isEmpty(request.getTableName())) {
+				throw new AdempiereException("@AD_Table_ID@ @NotFound@");
+			}
+			
 			if (!Util.isEmpty(request.getUuid()) || request.getId() > 0) {
 				PO entity = RecordUtil.getEntity(context, request.getTableName(), request.getUuid(), request.getId(), transactionName);
 				if (entity != null && entity.get_ID() > 0) {
@@ -606,6 +610,10 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 	 * @return
 	 */
 	private Entity.Builder updateEntity(Properties context, UpdateEntityRequest request) {
+		if(Util.isEmpty(request.getTableName())) {
+			throw new AdempiereException("@AD_Table_ID@ @NotFound@");
+		}
+		
 		PO entity = RecordUtil.getEntity(context, request.getTableName(), request.getUuid(), request.getId(), null);
 		if(entity != null
 				&& entity.get_ID() >= 0) {


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Screenshot or Gif

Smart Browser without table:

![Screenshot_20220719_155200](https://user-images.githubusercontent.com/20288327/179839213-e94250bd-f89b-47b1-ad6b-f330437b88b9.png)

If you do not have a table configured in the smart browser and you send the request to delete it, it should throw an error on the server:

https://user-images.githubusercontent.com/20288327/179839263-31f8eb7b-172d-4f05-8070-3fea181441c1.mp4

If you do not have a table configured in the smart browser, the delete option should not be enabled:

https://user-images.githubusercontent.com/20288327/179839259-e8ab5181-f88e-427f-a23d-47c397ecce89.mp4


#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/128
