### PR TITLE
fix: Business partner pagination.

### DIFF
--- a/src/main/java/org/spin/base/util/RecordUtil.java
+++ b/src/main/java/org/spin/base/util/RecordUtil.java
@@ -45,7 +45,7 @@ import org.spin.util.AttachmentUtil;
  */
 public class RecordUtil {
 	/**	Page Size	*/
-	public static final int PAGE_SIZE = 50;
+	public static final int PAGE_SIZE = 15;
 	
 	/**
 	 * Get Page Size from client, else from default

--- a/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
+++ b/src/main/java/org/spin/grpc/service/CoreFunctionalityImplementation.java
@@ -316,7 +316,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
-		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
+		int limit = RecordUtil.getPageSize(request.getPageSize());
 		//	Get business partner list
 		//	Dynamic where clause
 		StringBuffer whereClause = new StringBuffer();
@@ -765,7 +765,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
-		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
+		int limit = RecordUtil.getPageSize(request.getPageSize());
 		Query query = new Query(Env.getCtx(), I_AD_Org.Table_Name, whereClause, null)
 				.setParameters(parameters)
 				.setOnlyActiveRecords(true)
@@ -799,7 +799,7 @@ public class CoreFunctionalityImplementation extends CoreFunctionalityImplBase {
 		String nexPageToken = null;
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
-		int limit = (pageNumber + 1) * RecordUtil.getPageSize(request.getPageSize());
+		int limit = RecordUtil.getPageSize(request.getPageSize());
 		int id = request.getOrganizationId();
 		if(id <= 0) {
 			id = RecordUtil.getIdFromUuid(I_AD_Org.Table_Name, request.getOrganizationUuid(), null);


### PR DESCRIPTION
The number of records per page set on the client side is 15, which must match on the server side, additionally when you go to the second page you never get records because the calculation of the page number is incorrect.



https://user-images.githubusercontent.com/20288327/180312005-37b28b3c-c3b4-42b6-b06d-6a631e65e1a2.mp4

