### PR TITLE
fix: Business Partner Info displayed value.

### DIFF
--- a/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/BusinessDataServiceImplementation.java
@@ -759,8 +759,8 @@ public class BusinessDataServiceImplementation extends BusinessDataImplBase {
 							String value = rs.getString(index);
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
+							valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							continue;
 						}
 						//	From field

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1036,10 +1036,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 							String value = rs.getString(index);
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
-							} else {
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
+							valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							continue;
 						}
 						if (field.isKey()) {
@@ -1231,10 +1229,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 							String value = rs.getString(index);
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
-							} else {
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
+							valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							continue;
 						}
 						if (field.isKey()) {
@@ -3124,14 +3120,14 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 					try {
 						String columnName = metaData.getColumnName (index);
 						MBrowseField field = fieldsMap.get(columnName.toUpperCase());
-						Value.Builder valueBuilder = null;
+						Value.Builder valueBuilder = Value.newBuilder();;
 						//	Display Columns
 						if(field == null) {
 							String value = rs.getString(index);
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
-								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
+							valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							continue;
 						}
 						//	From field

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -1037,6 +1037,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
 								valueObjectBuilder.putValues(columnName, valueBuilder.build());
+							} else {
+								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
 							continue;
 						}
@@ -1229,6 +1231,8 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 							String value = rs.getString(index);
 							if(!Util.isEmpty(value)) {
 								valueBuilder = ValueUtil.getValueFromString(value);
+								valueObjectBuilder.putValues(columnName, valueBuilder.build());
+							} else {
 								valueObjectBuilder.putValues(columnName, valueBuilder.build());
 							}
 							continue;


### PR DESCRIPTION
<!--
    Note: In order to better solve your problem, please refer to the template to provide complete information, accurately describe the problem, and the incomplete information issue will be closed.
-->
## Bug report / Feature

#### Steps to reproduce

1. Open `User` window.
2. Show `Business Partner` field.

A. Without save changes.
1. Select a record without `Business Partner`.
2. Set any `Business Partner`.

B. Without clear displayed value.
1. Select a record with `Business Partner`.
2. Click on `New`.

#### Screenshot or Gif

Before this changes:

https://user-images.githubusercontent.com/20288327/180478646-5ec2e1ae-4ade-474e-8b01-f04c3324eb27.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/180478650-9c22606a-db49-4c79-abb4-cc047f7a6eac.mp4

#### Expected behavior
A. When fill `Business Partner` field, change value and `Save` are displayed.
B. When clic on `New` button, clear old set value.

#### Other relevant information
- Your OS: Kubuntut 20.4 x64.
- Web Browser: Mozilla Firefox 101.0.1.
- Node.js version: 14.18.0.
- Yarn version: 1.22.15.
- adempiere-vue version: 4.4.0.

#### Additional context
fixes: https://github.com/solop-develop/frontend-core/issues/247

