### PR TITLE
fix: io.vavr lib.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 	implementation 'com.lowagie:itext:2.1.7'
 	
 	// ADempiere external lib
-	implementation 'io.vavr:vavr:1.0.0-alpha-4'
+	// implementation 'io.vavr:vavr:1.0.0-alpha-4'
 	
 	//	ADempiere Core
 	implementation 'io.github.adempiere:base:3.9.4-develop-1.3'

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -1699,7 +1699,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			+ " INNER JOIN AD_Field f ON (tab.AD_Tab_ID=f.AD_Tab_ID AND f.AD_Column_ID=c.AD_Column_ID) "
 			+ " WHERE t.AD_Table_ID=? "
 			+ " AND (c.IsKey='Y' OR "
-			//	+ " (f.IsDisplayed='Y' AND f.IsEncrypted='N' AND f.ObscureType IS NULL)) "
+				// + " (f.IsDisplayed='Y' AND f.IsEncrypted='N' AND f.ObscureType IS NULL)) "
 				+ " (f.IsEncrypted='N' AND f.ObscureType IS NULL)) "
 			+ "ORDER BY c.IsKey DESC, f.SeqNo";
 		/*
@@ -1722,14 +1722,16 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			pstmt = DB.prepareStatement(sql, null);
 			pstmt.setInt(1, table.getAD_Table_ID());
 			resultSet = pstmt.executeQuery();
-
+			int recordCount = 0;
 			while (resultSet.next()) {
 				MField field = new MField(context, resultSet.getInt(MField.COLUMNNAME_AD_Field_ID), null);
 				if (field != null) {
 					Field.Builder fieldBuilder = convertField(context, field, true);
 					fieldsListBuilder.addFields(fieldBuilder.build());
 				}
+				recordCount++;
 			}
+			fieldsListBuilder.setRecordCount(recordCount);
 			resultSet.close();
 			pstmt.close();
 		}


### PR DESCRIPTION

```log


Exception in thread "grpc-default-executor-4" java.lang.IncompatibleClassChangeError: Method 'io.vavr.collection.List io.vavr.collection.List.ofAll(java.lang.Iterable)' must be Methodref constant
	at org.compiere.util.Login.getAuthenticatedUserId(Login.java:308)
	at org.spin.grpc.service.AccessServiceImplementation.getUserId(AccessServiceImplementation.java:289)
	at org.spin.grpc.service.AccessServiceImplementation.createSession(AccessServiceImplementation.java:314)
	at org.spin.grpc.service.AccessServiceImplementation.runLogin(AccessServiceImplementation.java:102)
	at org.spin.grpc.util.SecurityGrpc$MethodHandlers.invoke(SecurityGrpc.java:728)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:710)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "grpc-default-executor-5" java.lang.IncompatibleClassChangeError: Method 'io.vavr.collection.List io.vavr.collection.List.ofAll(java.lang.Iterable)' must be Methodref constant
	at org.compiere.util.Login.getAuthenticatedUserId(Login.java:308)
	at org.spin.grpc.service.AccessServiceImplementation.getUserId(AccessServiceImplementation.java:289)
	at org.spin.grpc.service.AccessServiceImplementation.createSession(AccessServiceImplementation.java:314)
	at org.spin.grpc.service.AccessServiceImplementation.runLogin(AccessServiceImplementation.java:102)
	at org.spin.grpc.util.SecurityGrpc$MethodHandlers.invoke(SecurityGrpc.java:728)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:710)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "grpc-default-executor-6" java.lang.IncompatibleClassChangeError: Method 'io.vavr.collection.List io.vavr.collection.List.ofAll(java.lang.Iterable)' must be Methodref constant
	at org.compiere.util.Login.getAuthenticatedUserId(Login.java:308)
	at org.spin.grpc.service.AccessServiceImplementation.getUserId(AccessServiceImplementation.java:289)
	at org.spin.grpc.service.AccessServiceImplementation.createSession(AccessServiceImplementation.java:314)
	at org.spin.grpc.service.AccessServiceImplementation.runLogin(AccessServiceImplementation.java:102)
	at org.spin.grpc.util.SecurityGrpc$MethodHandlers.invoke(SecurityGrpc.java:728)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:710)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "grpc-default-executor-7" java.lang.IncompatibleClassChangeError: Method 'io.vavr.collection.List io.vavr.collection.List.ofAll(java.lang.Iterable)' must be Methodref constant
	at org.compiere.util.Login.getAuthenticatedUserId(Login.java:308)
	at org.spin.grpc.service.AccessServiceImplementation.getUserId(AccessServiceImplementation.java:289)
	at org.spin.grpc.service.AccessServiceImplementation.createSession(AccessServiceImplementation.java:314)
	at org.spin.grpc.service.AccessServiceImplementation.runLogin(AccessServiceImplementation.java:102)
	at org.spin.grpc.util.SecurityGrpc$MethodHandlers.invoke(SecurityGrpc.java:728)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:710)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Exception in thread "grpc-default-executor-8" java.lang.IncompatibleClassChangeError: Method 'io.vavr.collection.List io.vavr.collection.List.ofAll(java.lang.Iterable)' must be Methodref constant
	at org.compiere.util.Login.getAuthenticatedUserId(Login.java:308)
	at org.spin.grpc.service.AccessServiceImplementation.getUserId(AccessServiceImplementation.java:289)
	at org.spin.grpc.service.AccessServiceImplementation.createSession(AccessServiceImplementation.java:314)
	at org.spin.grpc.service.AccessServiceImplementation.runLogin(AccessServiceImplementation.java:102)
	at org.spin.grpc.util.SecurityGrpc$MethodHandlers.invoke(SecurityGrpc.java:728)
	at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:171)
	at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:283)
	at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:710)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)

```