### PR TITLE
fix: POS Discount order line.

### DIFF
--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -538,17 +538,23 @@ public class ConvertUtil {
 		BigDecimal totalLines = orderLines.stream()
 				.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
 				.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO)).reduce(BigDecimal.ZERO, BigDecimal::add);
+
+		// discount
 		BigDecimal discountAmount = orderLines.stream()
-				.filter(orderLine -> orderLine.getC_Charge_ID() > 0 && orderLine.getC_Charge_ID() == defaultDiscountChargeId)
-				.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO)).reduce(BigDecimal.ZERO, BigDecimal::add);
+			.filter(orderLine -> orderLine.getC_Charge_ID() > 0 && orderLine.getC_Charge_ID() == defaultDiscountChargeId)
+			.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO))
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
 		BigDecimal lineDiscountAmount = orderLines.stream()
-				.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
-				.map(orderLine -> {
-					BigDecimal priceActualAmount = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
-					BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
-					return priceListAmount.subtract(priceActualAmount);
-				})
-				.reduce(BigDecimal.ZERO, BigDecimal::add);
+			.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
+			.map(orderLine -> {
+				BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
+				BigDecimal priceActualAmount = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
+				BigDecimal discountLine = priceListAmount.subtract(priceActualAmount)
+					.multiply(Optional.ofNullable(orderLine.getQtyOrdered()).orElse(Env.ZERO));
+				return discountLine;
+			})
+			.reduce(BigDecimal.ZERO, BigDecimal::add);
+
 		//	
 		discountAmount = discountAmount.add(lineDiscountAmount);
 		//	

--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -541,19 +541,18 @@ public class ConvertUtil {
 
 		// discount
 		BigDecimal discountAmount = orderLines.stream()
-			.filter(orderLine -> orderLine.getC_Charge_ID() > 0 && orderLine.getC_Charge_ID() == defaultDiscountChargeId)
-			.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO))
-			.reduce(BigDecimal.ZERO, BigDecimal::add);
+				.filter(orderLine -> orderLine.getC_Charge_ID() > 0 && orderLine.getC_Charge_ID() == defaultDiscountChargeId)
+				.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO)).reduce(BigDecimal.ZERO, BigDecimal::add);
 		BigDecimal lineDiscountAmount = orderLines.stream()
-			.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
-			.map(orderLine -> {
-				BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
-				BigDecimal priceActualAmount = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
-				BigDecimal discountLine = priceListAmount.subtract(priceActualAmount)
-					.multiply(Optional.ofNullable(orderLine.getQtyOrdered()).orElse(Env.ZERO));
-				return discountLine;
-			})
-			.reduce(BigDecimal.ZERO, BigDecimal::add);
+				.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
+				.map(orderLine -> {
+					BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
+					BigDecimal priceActualAmount = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
+					BigDecimal discountLine = priceListAmount.subtract(priceActualAmount)
+						.multiply(Optional.ofNullable(orderLine.getQtyOrdered()).orElse(Env.ZERO));
+					return discountLine;
+				})
+				.reduce(BigDecimal.ZERO, BigDecimal::add);
 
 		//	
 		discountAmount = discountAmount.add(lineDiscountAmount);

--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -546,8 +546,8 @@ public class ConvertUtil {
 		BigDecimal lineDiscountAmount = orderLines.stream()
 				.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
 				.map(orderLine -> {
-					BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
 					BigDecimal priceActualAmount = Optional.ofNullable(orderLine.getPriceActual()).orElse(Env.ZERO);
+					BigDecimal priceListAmount = Optional.ofNullable(orderLine.getPriceList()).orElse(Env.ZERO);
 					BigDecimal discountLine = priceListAmount.subtract(priceActualAmount)
 						.multiply(Optional.ofNullable(orderLine.getQtyOrdered()).orElse(Env.ZERO));
 					return discountLine;

--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -538,8 +538,6 @@ public class ConvertUtil {
 		BigDecimal totalLines = orderLines.stream()
 				.filter(orderLine -> orderLine.getC_Charge_ID() != defaultDiscountChargeId || defaultDiscountChargeId == 0)
 				.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO)).reduce(BigDecimal.ZERO, BigDecimal::add);
-
-		// discount
 		BigDecimal discountAmount = orderLines.stream()
 				.filter(orderLine -> orderLine.getC_Charge_ID() > 0 && orderLine.getC_Charge_ID() == defaultDiscountChargeId)
 				.map(orderLine -> Optional.ofNullable(orderLine.getLineNetAmt()).orElse(Env.ZERO)).reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -16,6 +16,7 @@ package org.spin.grpc.service;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -4414,7 +4415,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		BigDecimal multiplier = Env.ONE.subtract(discount.divide(Env.ONEHUNDRED, MathContext.DECIMAL128));
 		//	B = A / 100
 		BigDecimal finalPrice = basePrice.multiply(multiplier);
-		finalPrice = finalPrice.setScale(precision, BigDecimal.ROUND_HALF_UP);
+		finalPrice = finalPrice.setScale(precision, RoundingMode.HALF_UP);
 		return finalPrice;
 	}
 	
@@ -4435,7 +4436,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 			discount = discount.multiply(Env.ONEHUNDRED);
 		}
 		if (discount.scale() > precision) {
-			discount = discount.setScale(precision, BigDecimal.ROUND_HALF_UP);
+			discount = discount.setScale(precision, RoundingMode.HALF_UP);
 		}
 		return discount.negate();
 	}

--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -16,7 +16,6 @@ package org.spin.grpc.service;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.math.RoundingMode;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
@@ -4415,7 +4414,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		BigDecimal multiplier = Env.ONE.subtract(discount.divide(Env.ONEHUNDRED, MathContext.DECIMAL128));
 		//	B = A / 100
 		BigDecimal finalPrice = basePrice.multiply(multiplier);
-		finalPrice = finalPrice.setScale(precision, RoundingMode.HALF_UP);
+		finalPrice = finalPrice.setScale(precision, BigDecimal.ROUND_HALF_UP);
 		return finalPrice;
 	}
 	
@@ -4436,7 +4435,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 			discount = discount.multiply(Env.ONEHUNDRED);
 		}
 		if (discount.scale() > precision) {
-			discount = discount.setScale(precision, RoundingMode.HALF_UP);
+			discount = discount.setScale(precision, BigDecimal.ROUND_HALF_UP);
 		}
 		return discount.negate();
 	}

--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -410,19 +410,20 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 				throw new AdempiereException("Object Request Null");
 			}
 			log.fine("Add Line for Order = " + request.getOrderLineUuid());
-			ContextManager.getContext(request.getClientRequest());
+			ContextManager.getContext(request.getClientRequest().getSessionUuid(),
+					request.getClientRequest().getLanguage(),
+					request.getClientRequest().getOrganizationUuid(),
+					request.getClientRequest().getWarehouseUuid());
 			OrderLine.Builder orderLine = updateAndConvertOrderLine(request);
 			responseObserver.onNext(orderLine.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
-			responseObserver.onError(
-				Status.INTERNAL
+			responseObserver.onError(Status.INTERNAL
 					.withDescription(e.getLocalizedMessage())
 					.augmentDescription(e.getLocalizedMessage())
 					.withCause(e)
-					.asRuntimeException()
-			);
+					.asRuntimeException());
 		}
 	}
 	
@@ -4740,14 +4741,12 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		}
 		//	Quantity
 		return ConvertUtil.convertOrderLine(
-			updateOrderLine(orderLineId,
-				ValueUtil.getBigDecimalFromDecimal(request.getQuantity()),
-				ValueUtil.getBigDecimalFromDecimal(request.getPrice()),
-				ValueUtil.getBigDecimalFromDecimal(request.getDiscountRate()),
-				request.getIsAddQuantity(),
-				RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null)
-			)
-		);
+				updateOrderLine(orderLineId,
+						ValueUtil.getBigDecimalFromDecimal(request.getQuantity()),
+						ValueUtil.getBigDecimalFromDecimal(request.getPrice()),
+						ValueUtil.getBigDecimalFromDecimal(request.getDiscountRate()),
+						request.getIsAddQuantity(),
+						RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null)));
 	}
 	
 	/**
@@ -4771,14 +4770,11 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		}
 		//	Quantity
 		return ConvertUtil.convertOrderLine(
-			addOrderLine(
-				orderId,
-				RecordUtil.getIdFromUuid(I_M_Product.Table_Name, request.getProductUuid(), null),
-				RecordUtil.getIdFromUuid(I_C_Charge.Table_Name, request.getChargeUuid(), null),
-				RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null),
-				ValueUtil.getBigDecimalFromDecimal(request.getQuantity())
-			)
-		);
+				addOrderLine(orderId,
+						RecordUtil.getIdFromUuid(I_M_Product.Table_Name, request.getProductUuid(), null),
+						RecordUtil.getIdFromUuid(I_C_Charge.Table_Name, request.getChargeUuid(), null),
+						RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null),
+						ValueUtil.getBigDecimalFromDecimal(request.getQuantity())));
 	}
 	
 	/***

--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -410,9 +410,9 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 				throw new AdempiereException("Object Request Null");
 			}
 			log.fine("Add Line for Order = " + request.getOrderLineUuid());
-			ContextManager.getContext(request.getClientRequest().getSessionUuid(),
-					request.getClientRequest().getLanguage(),
-					request.getClientRequest().getOrganizationUuid(),
+			ContextManager.getContext(request.getClientRequest().getSessionUuid(), 
+					request.getClientRequest().getLanguage(), 
+					request.getClientRequest().getOrganizationUuid(), 
 					request.getClientRequest().getWarehouseUuid());
 			OrderLine.Builder orderLine = updateAndConvertOrderLine(request);
 			responseObserver.onNext(orderLine.build());
@@ -4741,9 +4741,9 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		}
 		//	Quantity
 		return ConvertUtil.convertOrderLine(
-				updateOrderLine(orderLineId,
-						ValueUtil.getBigDecimalFromDecimal(request.getQuantity()),
-						ValueUtil.getBigDecimalFromDecimal(request.getPrice()),
+				updateOrderLine(orderLineId, 
+						ValueUtil.getBigDecimalFromDecimal(request.getQuantity()), 
+						ValueUtil.getBigDecimalFromDecimal(request.getPrice()), 
 						ValueUtil.getBigDecimalFromDecimal(request.getDiscountRate()),
 						request.getIsAddQuantity(),
 						RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null)));
@@ -4770,10 +4770,10 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		}
 		//	Quantity
 		return ConvertUtil.convertOrderLine(
-				addOrderLine(orderId,
-						RecordUtil.getIdFromUuid(I_M_Product.Table_Name, request.getProductUuid(), null),
-						RecordUtil.getIdFromUuid(I_C_Charge.Table_Name, request.getChargeUuid(), null),
-						RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null),
+				addOrderLine(orderId, 
+						RecordUtil.getIdFromUuid(I_M_Product.Table_Name, request.getProductUuid(), null), 
+						RecordUtil.getIdFromUuid(I_C_Charge.Table_Name, request.getChargeUuid(), null), 
+						RecordUtil.getIdFromUuid(I_M_Warehouse.Table_Name, request.getWarehouseUuid(), null), 
 						ValueUtil.getBigDecimalFromDecimal(request.getQuantity())));
 	}
 	


### PR DESCRIPTION

- Edit quantity only no longer removes the value set in the discount line.
- Edit quantity if discounted totals the discount of the order.
- Edit price only no longer removes the value set in the discount line.
- Add line with the same product updates the order discount total if that line is already discounted.


https://user-images.githubusercontent.com/20288327/186472163-4c9328ca-cee5-4aeb-b0be-a025f606bbac.mp4

