### PR TITLE
fix: Validate pin and default camaign.

### DIFF
--- a/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/PointOfSalesServiceImplementation.java
@@ -4493,7 +4493,7 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 				+ "		AND seller.IsActive = 'N' AND seller.IsAllowsPOSManager = 'Y' "
 				+ 		whereClause
 				+ ") "
-				+ "OR IsPOSManager = 'Y') s"
+				+ "OR IsPOSManager = 'Y') "
 				+ "AND UserPIN = ? "
 				,
 				null
@@ -5024,6 +5024,15 @@ public class PointOfSalesServiceImplementation extends StoreImplBase {
 		if(pos.get_ValueAsInt("C_DocTypeRMA_ID") > 0) {
 			builder.setReturnDocumentType(ConvertUtil.convertDocumentType(MDocType.get(Env.getCtx(), pos.get_ValueAsInt("C_DocTypeRMA_ID"))));
 		}
+		// Campaign
+		if (pos.get_ValueAsInt("DefaultCampaign_ID") > 0) {
+			builder.setDefaultCampaignUuid(
+				ValueUtil.validateNull(
+					RecordUtil.getUuidFromId(I_C_Campaign.Table_Name, pos.get_ValueAsInt("DefaultCampaign_ID"))
+				)
+			);
+		}
+		
 		return builder;
 	}
 	


### PR DESCRIPTION

- Default campaign is null on point of sales attributes.

- When validate pin generate exception:


```log
===========> PointOfSalesServiceImplementation.validatePIN: org.postgresql.util.PSQLException: ERROR: syntax error at or near "sAND"
  Position: 287, SQL=SELECT AD_User_ID FROM AD_User WHERE ((EXISTS(             SELECT 1 FROM C_POSSellerAllocation AS seller           WHERE seller.C_POS_ID = ? AND seller.SalesRep_ID = AD_User.AD_User_ID           AND seller.IsActive = 'N' AND seller.IsAllowsPOSManager = 'Y'  AND seller.IsAllowsCreateOrder= 'Y') OR IsPOSManager = 'Y') sAND UserPIN = ? ) AND IsActive=? [43]
```

