### PR TITLE
fix: WF document action entity and record key.

### DIFF
--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -554,7 +554,22 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 	 * @return
 	 */
 	private ListDocumentActionsResponse.Builder convertDocumentActions(Properties context, ListDocumentActionsRequest request) {
+		if(request.getId() <= 0 && Util.isEmpty(request.getUuid())) {
+			throw new AdempiereException("@Record_ID@ / @UUID@ @NotFound@");
+		}
+		if(Util.isEmpty(request.getTableName())) {
+			throw new AdempiereException("@AD_Table_ID@ @NotFound@");
+		}
+		//	
+		MTable table = MTable.get(context, request.getTableName());
+		if(table == null || table.getAD_Table_ID() == 0) {
+			throw new AdempiereException("@AD_Table_ID@ @Invalid@");
+		}
 		PO entity = RecordUtil.getEntity(context, request.getTableName(), request.getUuid(), request.getId(), null);
+		if (entity == null) {
+			throw new AdempiereException("@Error@ @PO@ @NotFound@");
+		}
+
 		//	
 		String documentStatus = entity.get_ValueAsString(I_C_Order.COLUMNNAME_DocStatus);
 		String documentAction = entity.get_ValueAsString(I_C_Order.COLUMNNAME_DocAction);


### PR DESCRIPTION
http://0.0.0.0:8085/api/adempiere/workflow/document-actions?uuid=create-new&table_name=R_Request&pageToken=&pageSize=0&token=ce190db2-11b8-4bf8-baf2-45c1da98646e&language=es

Before this changes:

```log
===========> WorkflowServiceImplementation.listDocumentActions: Cannot invoke "org.compiere.model.PO.get_ValueAsString(String)" because "entity" is null [30]
```


After this changes:
```log
===========> WorkflowServiceImplementation.listDocumentActions: Error:  PO * No encontrado * [37]
```
![Screenshot_20220831_123326](https://user-images.githubusercontent.com/20288327/187731469-26c8d21a-727b-4fdf-8c7a-9933aab50ead.png)

