### PR TITLE
fix: Warning null on convertUserInfo.

### DIFF
--- a/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
@@ -592,7 +592,9 @@ public class AccessServiceImplementation extends SecurityImplBase {
 		if(value == null) {
 			String sessionTimeoutAsString = MSysConfig.getValue("WEBUI_DEFAULT_TIMEOUT", Env.getAD_Client_ID(Env.getCtx()), 0);
 			try {
-				sessionTimeout = Long.parseLong(sessionTimeoutAsString);
+				if (!Util.isEmpty(sessionTimeoutAsString, true)) {
+					sessionTimeout = Long.parseLong(sessionTimeoutAsString);
+				}
 			} catch (Exception e) {
 				log.severe(e.getLocalizedMessage());
 			}


### PR DESCRIPTION

#### Steps to Reproduce:
1. Run login.
2. Get session.

http://localhost:8085/api/adempiere/user/session?token=25733eea-10e2-456c-aad1-7c52a9f5cd86&language=es

Log on backend:

```log
===========> AccessServiceImplementation.convertUserInfo: null [30]
===========> AccessServiceImplementation.convertUserInfo: null [30
```