### PR TITLE
fix: Save accouting combination without alias.

### DIFF
--- a/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
@@ -238,7 +238,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		int accoutingSchemaId = (int) contextAttributesList.get(MAccount.COLUMNNAME_C_AcctSchema_ID);
 		MAcctSchema accoutingSchema = MAcctSchema.get(context, accoutingSchemaId, null);
 
-		String accountingCombinationAlias = (String) contextAttributesList.get(MAccount.COLUMNNAME_Alias);
+		String accountingCombinationAlias = ValueUtil.validateNull((String) contextAttributesList.get(MAccount.COLUMNNAME_Alias));
 		
 		List<MAcctSchemaElement> acctingSchemaElements = Arrays.asList(accoutingSchema.getAcctSchemaElements());
 
@@ -248,7 +248,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		int clientId = Env.getContextAsInt(context, windowNo, MAccount.COLUMNNAME_AD_Client_ID);
 
 		int accountingCombinationId = 0;
-		String accountingAlias = null;
+		String accountingAlias = "";
 		try {
 			PreparedStatement pstmt = DB.prepareStatement(sql.toString(), null);
 			pstmt.setInt(1, clientId);
@@ -256,7 +256,7 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 			ResultSet rs = pstmt.executeQuery();
 			if (rs.next()) {
 				accountingCombinationId = rs.getInt(1);
-				accountingAlias = rs.getString(2);
+				accountingAlias = ValueUtil.validateNull(rs.getString(2));
 			}
 			rs.close();
 			pstmt.close();
@@ -264,9 +264,6 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 		catch (SQLException e) {
 			log.log(Level.SEVERE, sql.toString(), e);
 			accountingCombinationId = 0;
-		}
-		if (accountingAlias == null) {
-			accountingAlias = "";
 		}
 
 		//	We have an account like this already - check alias
@@ -281,8 +278,11 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 				sql.append(" WHERE C_ValidCombination_ID=").append(accountingCombinationId);
 				int rowChanges = 0;
 				try {
-					PreparedStatement stmt = DB.prepareStatement(sql.toString(),
-							ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE, null
+					PreparedStatement stmt = DB.prepareStatement(
+						sql.toString(),
+						ResultSet.TYPE_FORWARD_ONLY,
+						ResultSet.CONCUR_UPDATABLE,
+						null
 					);
 					rowChanges = stmt.executeUpdate();
 					stmt.close();
@@ -309,14 +309,6 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 	}
 	
 	private MAccount setAccoutingCombinationByAttributes(int clientId, int organizationId, int accoutingSchemaId, int accountId, Map<String, Object> attributesList) {
-//		int clientId = 0;
-//		if (attributesList.get(MAccount.COLUMNNAME_AD_Client_ID) != null) {
-//			clientId = (int) attributesList.get(MAccount.COLUMNNAME_AD_Client_ID);
-//		}
-//		int organizationId = 0;
-//		if (attributesList.get(MAccount.COLUMNNAME_AD_Org_ID) != null) {
-//			organizationId = (int) attributesList.get(MAccount.COLUMNNAME_AD_Org_ID);
-//		}
 		String accoutingAlias = null;
 		if (attributesList.get(MAccount.COLUMNNAME_Alias) != null) {
 			accoutingAlias = (String) attributesList.get(MAccount.COLUMNNAME_Alias);


### PR DESCRIPTION
Request:

http://localhost:8085/api/adempiere/general-ledger/save-accounting-combination?http://20.12.0.113:8085/api/adempiere/general-ledger/accounting-combination?id=234&token=9d8439e8-cfe5-4d61-99a3-fe5d4b1a537d&language=esattributes[]=%7B%22value%22:11,%22key%22:%22AD_Org_ID%22%7D&attributes[]=%7B%22value%22:50025,%22key%22:%22Account_ID%22%7D&attributes[]=%7B%22value%22:100,%22key%22:%22C_Project_ID%22%7D&attributes[]=%7B%22value%22:101,%22key%22:%22C_Campaign_ID%22%7D&context_attributes[]=%7B%22value%22:11,%22key%22:%22AD_Org_ID%22%7D&context_attributes[]=%7B%22value%22:50025,%22key%22:%22Account_ID%22%7D&context_attributes[]=%7B%22key%22:%22C_AcctSchema_ID%22,%22value%22:101%7D&token=9d8439e8-cfe5-4d61-99a3-fe5d4b1a537d&language=es

Response:

```json
{
    "code": 500,
    "result": "Cannot invoke \"String.equals(Object)\" because \"accountingCombinationAlias\" is null"
}
```

