### PR TITLE
fixed: Default value on accouting combination field.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -72,7 +72,7 @@ public class DictionaryUtil {
 			if(displayTypeId == 0) {
 				displayTypeId = column.getAD_Reference_ID();
 			}
-			if (DisplayType.isLookup(displayTypeId) || DisplayType.Account == displayTypeId) {
+			if (ValueUtil.isLookup(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = field.getAD_Reference_Value_ID();
 				if(referenceValueId == 0) {
@@ -118,7 +118,7 @@ public class DictionaryUtil {
 		for (MColumn column : columnsList) {
 			int displayTypeId = column.getAD_Reference_ID();
 
-			if (DisplayType.isLookup(displayTypeId) || DisplayType.Account == displayTypeId) {
+			if (ValueUtil.isLookup(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = column.getAD_Reference_Value_ID();
 
@@ -361,7 +361,7 @@ public class DictionaryUtil {
 		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
 		for (MBrowseField browseField : ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID())) {
 			int displayTypeId = browseField.getAD_Reference_ID();
-			if(DisplayType.isLookup(displayTypeId)) {
+			if(ValueUtil.isLookup(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = browseField.getAD_Reference_Value_ID();
 				//	Validation Code

--- a/src/main/java/org/spin/base/util/ReferenceUtil.java
+++ b/src/main/java/org/spin/base/util/ReferenceUtil.java
@@ -70,10 +70,10 @@ public class ReferenceUtil {
 	 * @return
 	 */
 	public static boolean validateReference(int referenceId) {
-		if(!DisplayType.isLookup(referenceId) && DisplayType.Account != referenceId) {
-			return false;
+		if(DisplayType.isLookup(referenceId) || DisplayType.Account == referenceId) {
+			return true;
 		}
-		return true;
+		return false;
 	}
 	
 	/**
@@ -143,6 +143,9 @@ public class ReferenceUtil {
 			return null;
 		}
 		MLookupInfo lookupInformation = null;
+		if (DisplayType.Account == referenceId) {
+			columnName = I_C_ValidCombination.COLUMNNAME_C_ValidCombination_ID;
+		}
 		if(DisplayType.TableDir == referenceId
 				|| referenceValueId <= 0) {
 			//	Add Display

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2455,7 +2455,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				log.warning(e.getLocalizedMessage());
 			}
 		}
-		if(DisplayType.isLookup(referenceId)) {
+		if(ValueUtil.isLookup(referenceId)) {
 			if(referenceId == DisplayType.List) {
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, String.valueOf(defaultValueAsObject), null);
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));


### PR DESCRIPTION
If field Accouting Combination type has a default value will now return the expected structure instead of empty values

**Request:**

http://0.0.0.0:8085/api/adempiere/user-interface/window/default-value?field_uuid=8cebe6ca-fb40-11e8-a479-7a0060f0aa01&id=3916&value=234&token=7ce97e21-7704-4810-9260-4cf4c0a084b0&language=es

**Response:**
```json
{
    "code": 200,
    "result": {
        "id": 234,
        "uuid": "b79a94f4-6a04-4c0f-8293-8f29af5e4e29",
        "attributes": [
            {
                "key": "DisplayColumn",
                "value": "HQ-12110-_-_-_-_"
            },
            {
                "key": "KeyColumn",
                "value": 234
            },
            {
                "key": "UUID",
                "value": "b79a94f4-6a04-4c0f-8293-8f29af5e4e29"
            }
        ]
    }
}
```