### PR TITLE
fixed: Accouting Combination ignore alias filter.

### DIFF
--- a/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/GeneralLedgerServiceImplementation.java
@@ -402,8 +402,13 @@ public class GeneralLedgerServiceImplementation extends GeneralLedgerImplBase {
 				throw new AdempiereException("@" + columnName + "@ @IsMandatory@");
 			}
 
+			// The alias does not affect the query criteria
+			if (columnName == MAccount.COLUMNNAME_Alias) {
+				return;
+			}
+
 			sql.append(" AND ").append(columnName);
-			if (value == null) {
+			if (value == null || (value instanceof String && Util.isEmpty((String) value))) {
 				sql.append(" IS NULL ");
 			} else {
 				sql.append(" = ").append(value);


### PR DESCRIPTION

Before this changes:

https://user-images.githubusercontent.com/20288327/191953106-012f03d8-1909-421b-b0b7-d9cabbdd297e.mp4

After this changes:

https://user-images.githubusercontent.com/20288327/191953093-14d4ea92-8077-4ec9-bb70-c17f6a35c656.mp4

Request:
http://0.0.0.0:8085/api/adempiere/general-ledger/accounting-combinations?context_attributes[]=%7B%22key%22:%22C_AcctSchema_ID%22,%22value%22:101%7D&context_attributes[]=%7B%22key%22:%22AD_Org_ID%22,%22value%22:11%7D&context_attributes[]=%7B%22key%22:%22Account_ID%22,%22value%22:518%7D&filters[]=%7B%22column_name%22:%22AD_Org_ID%22,%22value%22:11%7D&filters[]=%7B%22column_name%22:%22Account_ID%22,%22value%22:518%7D&filters[]=%7B%22column_name%22:%22Alias%22,%22value%22:%22hq+project+%22%7D&page_token=7ce97e21-7704-4810-9260-4cf4c0a084b0-1&page_size=15&token=7ce97e21-7704-4810-9260-4cf4c0a084b0&language=es

