### PR TITLE
fixed: Ignore unsupported Display Column lookups.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -36,7 +36,6 @@ import org.compiere.model.MColumn;
 import org.compiere.model.MField;
 import org.compiere.model.MTab;
 import org.compiere.model.MTable;
-import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Language;
 import org.compiere.util.Util;
@@ -72,7 +71,7 @@ public class DictionaryUtil {
 			if(displayTypeId == 0) {
 				displayTypeId = column.getAD_Reference_ID();
 			}
-			if (ValueUtil.isLookup(displayTypeId)) {
+			if (ReferenceUtil.validateReference(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = field.getAD_Reference_Value_ID();
 				if(referenceValueId == 0) {
@@ -81,7 +80,6 @@ public class DictionaryUtil {
 				//	Validation Code
 				String columnName = column.getColumnName();
 				String tableName = table.getTableName();
-				queryToAdd.append(", ");
 				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(
 					Env.getCtx()).getReferenceInfo(displayTypeId,
 					referenceValueId,
@@ -90,6 +88,7 @@ public class DictionaryUtil {
 					tableName
 				);
 				if(referenceInfo != null) {
+					queryToAdd.append(", ");
 					String displayedColumn = referenceInfo.getDisplayValue(columnName);
 					queryToAdd.append(displayedColumn);
 					String joinClause = referenceInfo.getJoinValue(columnName, tableName);
@@ -118,13 +117,12 @@ public class DictionaryUtil {
 		for (MColumn column : columnsList) {
 			int displayTypeId = column.getAD_Reference_ID();
 
-			if (ValueUtil.isLookup(displayTypeId)) {
+			if (ReferenceUtil.validateReference(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = column.getAD_Reference_Value_ID();
 
 				String columnName = column.getColumnName();
 				String tableName = table.getTableName();
-				queryToAdd.append(", ");
 
 				//	Validation Code
 				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(
@@ -132,6 +130,7 @@ public class DictionaryUtil {
 					tableName
 				);
 				if(referenceInfo != null) {
+					queryToAdd.append(", ");
 					queryToAdd.append(referenceInfo.getDisplayValue(columnName));
 					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
 				}
@@ -361,7 +360,7 @@ public class DictionaryUtil {
 		StringBuffer joinsToAdd = new StringBuffer(originalQuery.substring(fromIndex, originalQuery.length() - 1));
 		for (MBrowseField browseField : ASPUtil.getInstance().getBrowseDisplayFields(browser.getAD_Browse_ID())) {
 			int displayTypeId = browseField.getAD_Reference_ID();
-			if(ValueUtil.isLookup(displayTypeId)) {
+			if (ReferenceUtil.validateReference(displayTypeId)) {
 				//	Reference Value
 				int referenceValueId = browseField.getAD_Reference_Value_ID();
 				//	Validation Code
@@ -375,9 +374,9 @@ public class DictionaryUtil {
 					MColumn column = MColumn.get(Env.getCtx(), viewColumn.getAD_Column_ID());
 					columnName = column.getColumnName();
 				}
-				queryToAdd.append(", ");
 				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx()).getReferenceInfo(displayTypeId, referenceValueId, columnName, Env.getAD_Language(Env.getCtx()), tableName);
 				if(referenceInfo != null) {
+					queryToAdd.append(", ");
 					queryToAdd.append(referenceInfo.getDisplayValue(viewColumn.getColumnName()));
 					joinsToAdd.append(referenceInfo.getJoinValue(columnName, tableName));
 				}

--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2455,7 +2455,7 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				log.warning(e.getLocalizedMessage());
 			}
 		}
-		if(ValueUtil.isLookup(referenceId)) {
+		if (ReferenceUtil.validateReference(referenceId)) {
 			if(referenceId == DisplayType.List) {
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, String.valueOf(defaultValueAsObject), null);
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));


### PR DESCRIPTION
Currently we were trying to generate the display column for fields that are not supported such as:
- Location.
- Product attributes.
- Location. 
 
Currently only are supported:
- Accounting combination.
- Table.
- Table direct.
- List.


#### Request

http://localhost:8085/api/adempiere/business-partner/grid?process_parameter_uuid=a43d0d9a-fb40-11e8-a479-7a0060f0aa01&table_name=C_BPartner&filters[]=%7B%22column_name%22:%22IsCustomer%22,%22value%22:true%7D&page_size=15&page_token=16df16fe-5bd5-44dc-95ad-bc63ed3a7556-1&token=16df16fe-5bd5-44dc-95ad-bc63ed3a7556&language=es


#### Response:

Before this changes:

![Screenshot_20220923_172544](https://user-images.githubusercontent.com/20288327/192058862-40ba1ade-0315-4e02-a54a-d541dae78d51.png)


After this changes:

![Screenshot_20220923_172350](https://user-images.githubusercontent.com/20288327/192058687-0185262f-7c51-4096-9f9f-038834ada68b.png)
