### PR TITLE
fix: POS rouding on available quantity.

### DIFF
--- a/src/main/java/org/spin/base/util/ConvertUtil.java
+++ b/src/main/java/org/spin/base/util/ConvertUtil.java
@@ -1035,7 +1035,7 @@ public class ConvertUtil {
 				.setWarehouse(convertWarehouse(orderLine.getM_Warehouse_ID()))
 				.setQuantity(ValueUtil.getDecimalFromBigDecimal(quantityEntered.setScale(priceList.getStandardPrecision(), BigDecimal.ROUND_HALF_UP)))
 				.setQuantityOrdered(ValueUtil.getDecimalFromBigDecimal(quantityOrdered.setScale(priceList.getStandardPrecision(), BigDecimal.ROUND_HALF_UP)))
-				.setAvailableQuantity(ValueUtil.getDecimalFromBigDecimal(availableQuantity.setScale(standardPrecision)))
+				.setAvailableQuantity(ValueUtil.getDecimalFromBigDecimal(availableQuantity.setScale(standardPrecision, BigDecimal.ROUND_HALF_UP)))
 				//	Prices
 				.setPriceList(ValueUtil.getDecimalFromBigDecimal(priceListAmount.setScale(priceList.getStandardPrecision(), BigDecimal.ROUND_HALF_UP)))
 				.setPrice(ValueUtil.getDecimalFromBigDecimal(priceAmount.setScale(priceList.getStandardPrecision(), BigDecimal.ROUND_HALF_UP)))


### PR DESCRIPTION

When creating an order, or listing an order, and the product has quantity available with decimal points in the precision greater than 2 digits (123456.123) generates the following message:

```log
===========> PointOfSalesServiceImplementation.createOrderLine: Rounding necessary [875]
===========> PointOfSalesServiceImplementation.createOrderLine: Rounding necessary [875]
```