### PR TITLE
fix: Display column on location address inverse.

### DIFF
--- a/src/main/java/org/spin/base/util/DictionaryUtil.java
+++ b/src/main/java/org/spin/base/util/DictionaryUtil.java
@@ -127,10 +127,14 @@ public class DictionaryUtil {
 				String tableName = table.getTableName();
 
 				//	Validation Code
-				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(
-					Env.getCtx()).getReferenceInfo(displayTypeId, referenceValueId, columnName, language.getAD_Language(),
-					tableName
-				);
+				ReferenceInfo referenceInfo = ReferenceUtil.getInstance(Env.getCtx())
+					.getReferenceInfo(
+						displayTypeId,
+						referenceValueId,
+						columnName,
+						language.getAD_Language(),
+						tableName
+					);
 				if(referenceInfo != null) {
 					queryToAdd.append(", ");
 					queryToAdd.append(referenceInfo.getDisplayValue(columnName));

--- a/src/main/java/org/spin/base/util/ReferenceUtil.java
+++ b/src/main/java/org/spin/base/util/ReferenceUtil.java
@@ -155,7 +155,7 @@ public class ReferenceUtil {
 	
 	
 	public static String getColunsOrderLocation(String displaySequence, boolean isAddressReverse) {
-		StringBuffer cityPostalRegion = new StringBuffer(" '' ");
+		StringBuffer cityPostalRegion = new StringBuffer();
 
 		String inStr = displaySequence.replace(",", "|| ', ' ");
 		String token;
@@ -178,12 +178,12 @@ public class ReferenceUtil {
 					.append("C_City.C_City_ID = C_Location.C_City_ID")
 					.append("), '') ");
 			} else if (token.equals("R")) {
-				String regionName = "";
+				// String regionName = "";
 				//  local region name
 				// if (!Util.isEmpty(country.getRegionName(), true)) {
 				//     regionName = " || ' " + country.getRegionName() + "'";
 				// }
-				cityPostalRegion.append("|| NVL((SELECT NVL(C_Region.Name" + regionName + ", '') FROM C_Region ")
+				cityPostalRegion.append("|| NVL((SELECT NVL(C_Region.Name, '') FROM C_Region ")
 					.append("WHERE C_Region.C_Region_ID = C_Location.C_Region_ID")
 					.append("), '') ");
 			} else if (token.equals("P")) {
@@ -199,8 +199,10 @@ public class ReferenceUtil {
 		}
 		cityPostalRegion.append(inStr); // add the rest of the string 
 
+		StringBuffer query = new StringBuffer();
 		if (isAddressReverse) {
-			cityPostalRegion
+			query.append("'' ")
+				.append(cityPostalRegion)
 				.append("|| ', ' ")
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address4 + " || ', ' , '') ")
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address3 + " || ', ' , '') ")
@@ -208,7 +210,7 @@ public class ReferenceUtil {
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address1 + ", '')")
 			;
 		} else {
-			cityPostalRegion = new StringBuffer()
+			query.append("'' ")
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address1 + " || ', ' , '') ")
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address2 + " || ', ' , '')  ")
 				.append("|| NVL(" + I_C_Location.Table_Name + "." + I_C_Location.COLUMNNAME_Address3 + " || ', ' , '')  ")
@@ -217,7 +219,7 @@ public class ReferenceUtil {
 			;
 		}
 
-		return cityPostalRegion.toString();
+		return query.toString();
 	}
 
 	public static String getDisplayColumnSQLLocation(String tableName, String columnName) {


### PR DESCRIPTION
When address is inverse on country client is error


#### Request

http://0.0.0.0:8085/api/adempiere/business-partner/grid?field_uuid=8cef47c0-fb40-11e8-a479-7a0060f0aa01&table_name=C_BPartner&filters[]=%7B%22column_name%22:%22IsCustomer%22,%22value%22:true%7D&page_size=15&page_token=aef4a788-bc50-443a-beb5-e3d3dbc0dde0-1&token=aef4a788-bc50-443a-beb5-e3d3dbc0dde0&language=es

#### Response

```json
{
    "code": 200,
    "result": {
        "record_count": 6,
        "next_page_token": "",
        "records": [
            {
                "id": 117,
                "uuid": "b7bafd8e-ae3b-4bbc-9a0d-d47fdbef390f",
                "table_name": "C_BPartner"
            }
        ]
    }
}
```

#### Additional context
https://github.com/solop-develop/frontend-core/issues/528
