### PR TITLE
fix: Login with Role UUID nonexistent.

### DIFF
--- a/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
@@ -338,19 +338,19 @@ public class AccessServiceImplementation extends SecurityImplBase {
 					I_AD_Role.Table_Name,
 					"UUID = ?",
 					null
-					)
+				)
 					.setParameters(request.getRoleUuid())
 					.first();
-				roleId = role.getAD_Role_ID();
-				if(role != null
-						&& !Optional.ofNullable(role.getUUID()).orElse("").equals(Optional.ofNullable(request.getRoleUuid()).orElse(""))) {
+				if (role == null) {
+					// get default role
 					roleId = DB.getSQLValue(null, sqlRole, userId);
+				} else {
+					roleId = role.getAD_Role_ID();
 				}
 				//	Organization
 				if(organizationId < 0) {
 					organizationId = RecordUtil.getIdFromUuid(I_AD_Org.Table_Name, request.getOrganizationUuid(), null);
 				}
-				
 			}
 			if(organizationId < 0) {
 				organizationId = SessionManager.getDefaultOrganizationId(roleId, userId);
@@ -592,7 +592,11 @@ public class AccessServiceImplementation extends SecurityImplBase {
 				userInfo.setImage(ValueUtil.validateNull(attachmentReference.getValidFileName()));
 			}
 		}
-		Object value = user.get_Value("ConnectionTimeout");
+		Object value = null;
+		// checks if the column exists in the database
+		if (user.get_ColumnIndex("ConnectionTimeout") >= 0) {
+			value = user.get_Value("ConnectionTimeout");
+		}
 		long sessionTimeout = 0;
 		if(value == null) {
 			String sessionTimeoutAsString = MSysConfig.getValue("WEBUI_DEFAULT_TIMEOUT", Env.getAD_Client_ID(Env.getCtx()), 0);


### PR DESCRIPTION
#### Request
```bash
curl --location --request POST 'http://0.0.0.0:8085/api/adempiere/user/login?language=es' \
--header 'Content-Type: application/json' \
--data-raw '{
    "username": "SuperUser",
    "password": "System",
    "role_uuid": "non-existent-role-uuid"
}'
```

#### Response
Before this changes:
```json
{
    "code": 500,
    "result": ""
}
```

```log
===========> AccessServiceImplementation.runLogin: null [25]
```

After this changes:
```json
{
    "code": 200,
    "result": "b1badcd7-b28d-4294-b484-27b6cc786d9b"
}
```


##### Additional context
Previously if a login was made with a role uuid that did not exist in the database, it generated an error, now if it fails, it logs in with the default role.
