### PR TITLE
fix: Null Pointer Exception Dependent Fields.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -1631,6 +1631,9 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 			})
 			.forEach(tab -> {
 				List<MField> fieldsList = ASPUtil.getInstance().getWindowFields(tab.getAD_Tab_ID());
+				if (fieldsList == null) {
+					return;
+				}
 
 				fieldsList.stream()
 					.filter(currentField -> {


### PR DESCRIPTION
When loaded window with dependencies in other tab generate NPE:


```log
DictionaryServiceImplementation.getField: Cannot invoke "java.util.List.stream()" because "fieldsList" is null [505]
```

