### PR TITLE
 fix: Dependencies fields on translation tab.

### DIFF
--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -1627,7 +1627,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 
 		tabsList.stream()
 			.filter(currentTab -> {
-				return currentTab.isActive();
+				return currentTab.isActive() && !currentTab.isTranslationTab();
 			})
 			.forEach(tab -> {
 				List<MField> fieldsList = ASPUtil.getInstance().getWindowFields(tab.getAD_Tab_ID());

--- a/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/DictionaryServiceImplementation.java
@@ -1627,6 +1627,7 @@ public class DictionaryServiceImplementation extends DictionaryImplBase {
 
 		tabsList.stream()
 			.filter(currentTab -> {
+				// transaltion tab is not rendering on client
 				return currentTab.isActive() && !currentTab.isTranslationTab();
 			})
 			.forEach(tab -> {


### PR DESCRIPTION
Translation tabs are not rendered on the client, so if you add fields dependent on a translation tab you will not get it on the client, so warnings will be displayed in the browser console.


Before this changes:

https://user-images.githubusercontent.com/20288327/199052317-f44916d8-62ed-450b-8976-a763182c3023.mp4

After this changes:


https://user-images.githubusercontent.com/20288327/199052308-085b5c7b-0fc4-49a2-baea-2bcda71e3de2.mp4
