### PR TITLE
fix: Search text with like as default operator.

### DIFF
--- a/src/main/java/org/spin/base/util/ValueUtil.java
+++ b/src/main/java/org/spin/base/util/ValueUtil.java
@@ -731,6 +731,9 @@ public class ValueUtil {
 		if(!Util.isEmpty(criteria.getWhereClause())) {
 			whereClause.append("(").append(criteria.getWhereClause()).append(")");
 		}
+		if (Util.isEmpty(tableName, true)) {
+			tableName = criteria.getTableName();
+		}
 		final MTable table = MTable.get(Env.getCtx(), tableName);
 		//	Validate
 		if (table == null || table.getAD_Table_ID() <= 0) {

--- a/src/main/java/org/spin/base/util/ValueUtil.java
+++ b/src/main/java/org/spin/base/util/ValueUtil.java
@@ -27,11 +27,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.adempiere.exceptions.AdempiereException;
+import org.compiere.model.I_AD_Column;
+import org.compiere.model.MColumn;
 import org.compiere.model.MQuery;
+import org.compiere.model.MTable;
 import org.compiere.model.PO;
+import org.compiere.model.Query;
 import org.compiere.util.CLogger;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
@@ -603,6 +606,31 @@ public class ValueUtil {
 		return operator;
 	}
 	
+	/**
+	 * Get default operator by display type
+	 * @param displayTypeId
+	 * @return
+	 */
+	public static int getDefaultOperatorByDisplayType(int displayTypeId) {
+		int operator = Operator.EQUAL_VALUE;
+		switch (displayTypeId) {
+			case DisplayType.String:
+			case DisplayType.Text:
+			case DisplayType.TextLong:
+			case DisplayType.Memo:
+			case DisplayType.FilePath:
+			case DisplayType.FileName:
+			case DisplayType.FilePathOrName:
+			case DisplayType.URL:
+			case DisplayType.PrinterName:
+				operator = Operator.LIKE_VALUE;
+				break;
+			default:
+				break;
+			}
+		return operator;
+	}
+
 	public static void setParametersFromObjectsList(PreparedStatement pstmt, List<Object> parameters) {
 		try {
 			AtomicInteger parameterIndex = new AtomicInteger(1);
@@ -703,32 +731,47 @@ public class ValueUtil {
 		if(!Util.isEmpty(criteria.getWhereClause())) {
 			whereClause.append("(").append(criteria.getWhereClause()).append(")");
 		}
-		AtomicReference<String> tableNameFromReference = new AtomicReference<String>(tableName);
-		if(Util.isEmpty(tableNameFromReference.get())) {
-			tableNameFromReference.set(criteria.getTableName());
-		}
+		final MTable table = MTable.get(Env.getCtx(), tableName);
 		//	Validate
-		if(Util.isEmpty(tableNameFromReference.get())) {
+		if (table == null || table.getAD_Table_ID() <= 0) {
 			throw new AdempiereException("@AD_Table_ID@ @NotFound@");
 		}
 		criteria.getConditionsList().stream()
 			.filter(condition -> !Util.isEmpty(condition.getColumnName()))
 			.forEach(condition -> {
+				int operatorValue = condition.getOperatorValue();
 				if(whereClause.length() > 0) {
 					whereClause.append(" AND ");
 				}
-				String colummName = tableNameFromReference.get() + "." + condition.getColumnName(); 
+				String colummName = table.getTableName() + "." + condition.getColumnName();
+				if (operatorValue == Operator.VOID_VALUE) {
+					MColumn column =  new Query(
+						Env.getCtx(),
+						I_AD_Column.Table_Name,
+						"AD_Table_ID = ? AND ColumnName = ? ",
+						null
+					)
+						.setParameters(table.getAD_Table_ID(), condition.getColumnName())
+						.first();
+					if (column != null) {
+						operatorValue = getDefaultOperatorByDisplayType(column.getAD_Reference_ID());
+					} else {
+						// no valid column set default operator
+						operatorValue = Operator.EQUAL_VALUE;
+					}
+				}
+
 				//	Open
 				whereClause.append("(");
-				if(condition.getOperatorValue() == Operator.LIKE_VALUE
-						|| condition.getOperatorValue() == Operator.NOT_LIKE_VALUE) {
+				if (operatorValue == Operator.LIKE_VALUE
+						|| operatorValue == Operator.NOT_LIKE_VALUE) {
 					colummName = "UPPER(" + colummName + ")";
 				}
 				//	Add operator
-				whereClause.append(colummName).append(convertOperator(condition.getOperatorValue()));
+				whereClause.append(colummName).append(convertOperator(operatorValue));
 				//	For in or not in
-				if(condition.getOperatorValue() == Operator.IN_VALUE
-						|| condition.getOperatorValue() == Operator.NOT_IN_VALUE) {
+				if(operatorValue == Operator.IN_VALUE
+						|| operatorValue == Operator.NOT_IN_VALUE) {
 					StringBuffer parameter = new StringBuffer();
 					condition.getValuesList().forEach(value -> {
 						if(parameter.length() > 0) {
@@ -738,16 +781,27 @@ public class ValueUtil {
 						params.add(ValueUtil.getObjectFromValue(value));
 					});
 					whereClause.append("(").append(parameter).append(")");
-				} else if(condition.getOperatorValue() == Operator.BETWEEN_VALUE) {
+				} else if(operatorValue == Operator.BETWEEN_VALUE) {
 					whereClause.append(" ? ").append(" AND ").append(" ?");
 					params.add(ValueUtil.getObjectFromValue(condition.getValue()));
 					params.add(ValueUtil.getObjectFromValue(condition.getValueTo()));
-				} else if(condition.getOperatorValue() == Operator.LIKE_VALUE
-						|| condition.getOperatorValue() == Operator.NOT_LIKE_VALUE) {
+				} else if(operatorValue == Operator.LIKE_VALUE
+						|| operatorValue == Operator.NOT_LIKE_VALUE) {
 					whereClause.append("?");
-					params.add(ValueUtil.getObjectFromValue(condition.getValue(), true));
-				} else if(condition.getOperatorValue() != Operator.NULL_VALUE
-						&& condition.getOperatorValue() != Operator.NOT_NULL_VALUE) {
+					String value = ValueUtil.validateNull(
+						(String) ValueUtil.getObjectFromValue(condition.getValue(), true)
+					);
+					if (!Util.isEmpty(value, true)) {
+						if (!value.startsWith("%")) {
+							value = "%" + value;
+						}
+						if (!value.endsWith("%")) {
+							value += "%"; 
+						}
+					}
+					params.add(value);
+				} else if(operatorValue != Operator.NULL_VALUE
+						&& operatorValue != Operator.NOT_NULL_VALUE) {
 					whereClause.append("?");
 					params.add(ValueUtil.getObjectFromValue(condition.getValue()));
 				}

--- a/src/main/proto/base_data_type.proto
+++ b/src/main/proto/base_data_type.proto
@@ -117,19 +117,20 @@ message Condition {
 	Value value_to = 3;
 	repeated Value values = 4;
 	enum Operator {
-		EQUAL = 0;
-		NOT_EQUAL = 1;
-		LIKE = 2;
-		NOT_LIKE = 3;
-		GREATER = 4;
-		GREATER_EQUAL = 5;
-		LESS = 6;
-		LESS_EQUAL = 7;
-		BETWEEN = 8;
-		NOT_NULL = 9;
-		NULL = 10;
-		IN = 11;
-		NOT_IN = 12;
+		VOID = 0;
+		EQUAL = 1;
+		NOT_EQUAL = 2;
+		LIKE = 3;
+		NOT_LIKE = 4;
+		GREATER = 5;
+		GREATER_EQUAL = 6;
+		LESS = 7;
+		LESS_EQUAL = 8;
+		BETWEEN = 9;
+		NOT_NULL = 10;
+		NULL = 11;
+		IN = 12;
+		NOT_IN = 13;
 	}
 	//	Operators
 	Operator operator = 5;


### PR DESCRIPTION
When a search is made for a text field and the LIKE operator was not sent, it takes EQUAL as the default operator, so an exact search had to be made.

A default operator called VOID is added, which when set, searches for the default operator according to the display type, for number type fields the EQUAL, for text type fields the LIKE operator.


#### Screenshot

https://user-images.githubusercontent.com/20288327/201457227-3583d223-1404-4c01-8f82-6983d72d3658.mp4



#### Additional context
Fixes https://github.com/solop-develop/frontend-core/issues/462