### PR TITLE
feat: Exists attachment on record.

### DIFF
--- a/src/main/proto/file_management.proto
+++ b/src/main/proto/file_management.proto
@@ -38,6 +38,8 @@ service FileManagement {
 	rpc LoadResource(stream LoadResourceRequest) returns (ResourceReference) {}
 	// Delete resource reference
 	rpc DeleteResourceReference(DeleteResourceReferenceRequest) returns (data.Empty) {}
+	// Exists Attachment on Record
+	rpc ExistsAttachment(ExistsAttachmentRequest) returns (ExistsAttachmentResponse) {}
 }
 
 // Resource Chunk
@@ -114,4 +116,15 @@ message DeleteResourceReferenceRequest {
 	int32 resource_id = 2;
 	string resource_uuid = 3;
 	string resource_name = 4;
+}
+
+message ExistsAttachmentRequest {
+	data.ClientRequest client_request = 1;
+	string table_name = 2;
+	int32 record_id = 3;
+	string record_uuid = 4;
+}
+
+message ExistsAttachmentResponse {
+	int32 record_count = 1;
 }


### PR DESCRIPTION
#### End point
http://0.0.0.0:8085/api/adempiere/user-interface/component/resource/exists-attachment?table_name=C_Greeting&record_id=1000003&record_uuid=7fd879af-78db-446e-9b92-1e893f03541b&token=71ab66dc-637f-43f9-a4e1-033d1c447956&language=es

#### Request
```bash
curl 'http://0.0.0.0:8085/api/adempiere/user-interface/component/resource/exists-attachment?table_name=C_Greeting&record_id=1000003&record_uuid=7fd879af-78db-446e-9b92-1e893f03541b&token=71ab66dc-637f-43f9-a4e1-033d1c447956&language=es' \
  -H 'Accept: application/json, text/plain, */*'
```

#### Response
```json
{
    "code": 200,
    "result": 3
}
```

#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/488

