### PR TITLE
fix: Get default value with single quotes.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -42,6 +42,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.script.ScriptEngine;
@@ -2534,7 +2536,16 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		}
 		if (ReferenceUtil.validateReference(referenceId)) {
 			if(referenceId == DisplayType.List) {
-				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, String.valueOf(defaultValueAsObject), null);
+				String singleQuotesPattern = "('|\")(\\w+)('|\")";
+				Matcher matcherSingleQuotes = Pattern.compile(
+					singleQuotesPattern,
+					Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+				)
+				.matcher(String.valueOf(defaultValueAsObject));
+				// remove single quotation mark 'DR' -> DR
+				String defaultValueList = matcherSingleQuotes.replaceAll("$2");
+
+				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, defaultValueList, null);
 				builder = convertDefaultValueFromResult(referenceList.getValue(), referenceList.getUUID(), referenceList.getValue(), referenceList.get_Translation(MRefList.COLUMNNAME_Name));
 			} else {
 				MLookupInfo lookupInfo = ReferenceUtil.getReferenceLookupInfo(referenceId, referenceValueId, columnName, validationRuleId);


### PR DESCRIPTION

#### Request

http://localhost:8085/api/adempiere/user-interface/window/default-value?field_uuid=8d8b5bba-fb40-11e8-a479-7a0060f0aa01&id=59390&value=%27DR%27&token=23b81174-fa45-40dc-8583-b176673f85eb&language=en&ts=1675266803201


#### Response

```json
{
  "code": 500,
  "result": ""
}
```

```log
===========> UserInterfaceServiceImplementation.getDefaultValue: null [206]
```

#### Before this changes

https://user-images.githubusercontent.com/20288327/216104449-037e12a6-9680-45be-a9da-634a1eeaa9d1.mp4


#### After this changes

https://user-images.githubusercontent.com/20288327/216104401-fc7422dc-5eb5-4bc3-a2c7-b6258570e9db.mp4




#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/818


