### PR TITLE
fix: Same start quotation with end quotation.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -2536,13 +2536,14 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		}
 		if (ReferenceUtil.validateReference(referenceId)) {
 			if(referenceId == DisplayType.List) {
-				String singleQuotesPattern = "('|\")(\\w+)('|\")";
+				// (') (text) (') or (") (text) (")
+				String singleQuotesPattern = "('|\")(\\w+)(\\1)";
 				Matcher matcherSingleQuotes = Pattern.compile(
 					singleQuotesPattern,
 					Pattern.CASE_INSENSITIVE | Pattern.DOTALL
 				)
 				.matcher(String.valueOf(defaultValueAsObject));
-				// remove single quotation mark 'DR' -> DR
+				// remove single quotation mark 'DR' -> DR, "DR" -> DR
 				String defaultValueList = matcherSingleQuotes.replaceAll("$2");
 
 				MRefList referenceList = MRefList.get(Env.getCtx(), referenceValueId, defaultValueList, null);


### PR DESCRIPTION

It is validated that the quotation mark at the beginning is equal to the quotation mark at the end, that is to say, if it starts with a single quotation mark it must end with the same, examples:
* `"DR'`: invalid
* `'DR"`: invalid
* `'DR'`: valid
* `"DR"`: valid





#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/818