### PR TITLE
fix: Smart Browser where clause with context columns.

### DIFF
--- a/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/UserInterfaceServiceImplementation.java
@@ -298,19 +298,16 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 				throw new AdempiereException("Browser Requested is Null");
 			}
 			log.fine("Object List Requested = " + request);
-			ContextManager.getContext(request.getClientRequest().getSessionUuid(), 
-					request.getClientRequest().getLanguage(), 
-					request.getClientRequest().getOrganizationUuid(), 
-					request.getClientRequest().getWarehouseUuid());
-			ListBrowserItemsResponse.Builder entityValueList = convertBrowserList(request);
+			ListBrowserItemsResponse.Builder entityValueList = listBrowserItems(request);
 			responseObserver.onNext(entityValueList.build());
 			responseObserver.onCompleted();
 		} catch (Exception e) {
 			log.severe(e.getLocalizedMessage());
 			responseObserver.onError(Status.INTERNAL
-					.withDescription(e.getLocalizedMessage())
-					.withCause(e)
-					.asRuntimeException());
+				.withDescription(e.getLocalizedMessage())
+				.withCause(e)
+				.asRuntimeException()
+			);
 		}
 	}
 
@@ -3036,24 +3033,33 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 	 * @param request
 	 * @return
 	 */
-	private ListBrowserItemsResponse.Builder convertBrowserList(ListBrowserItemsRequest request) {
+	private ListBrowserItemsResponse.Builder listBrowserItems(ListBrowserItemsRequest request) {
+		Properties context = ContextManager.getContext(request.getClientRequest());
+
 		ListBrowserItemsResponse.Builder builder = ListBrowserItemsResponse.newBuilder();
 		MBrowse browser = getBrowser(request.getUuid());
-		if(browser == null) {
+		if (browser == null || browser.getAD_Browse_ID() <= 0) {
 			return builder;
 		}
 		Criteria criteria = request.getCriteria();
 		HashMap<String, Object> parameterMap = new HashMap<>();
 		//	Populate map
-		criteria.getConditionsList().forEach(condition -> parameterMap.put(condition.getColumnName(), ValueUtil.getObjectFromValue(condition.getValue())));
+		criteria.getConditionsList().forEach(condition -> {
+			parameterMap.put(condition.getColumnName(), ValueUtil.getObjectFromValue(condition.getValue()));
+		});
+
+		//	Fill context
+		int windowNo = ThreadLocalRandom.current().nextInt(1, 8996 + 1);
+		context = ContextManager.setContextWithAttributes(windowNo, context, parameterMap);
+
 		List<Object> values = new ArrayList<Object>();
 		String whereClause = getBrowserWhereClause(browser, browser.getWhereClause(), request.getContextAttributesList(), parameterMap, values);
-		//	Page prefix
-		int page = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
+
 		String query = DictionaryUtil.addQueryReferencesFromBrowser(browser);
 		String orderByClause = DictionaryUtil.getSQLOrderBy(browser);
 		StringBuilder sql = new StringBuilder(query);
 		if (!Util.isEmpty(whereClause)) {
+			whereClause = Env.parseContext(context, windowNo, whereClause, false);
 			sql.append(" WHERE ").append(whereClause); // includes first AND
 		} else {
 			sql.append(" WHERE 1=1");
@@ -3074,16 +3080,14 @@ public class UserInterfaceServiceImplementation extends UserInterfaceImplBase {
 		} else {
 			orderByClause = " ORDER BY " + orderByClause;
 		}
+
 		//	Get page and count
 		int count = RecordUtil.countRecords(parsedSQL, tableName, tableNameAlias, values);
 		String nexPageToken = null;
-		int pageMultiplier = page == 0? 1: page;
-		if(count > (RecordUtil.getPageSize(request.getPageSize()) * pageMultiplier)) {
-			nexPageToken = RecordUtil.getPagePrefix(request.getClientRequest().getSessionUuid()) + (page + 1);
-		}
 		int pageNumber = RecordUtil.getPageNumber(request.getClientRequest().getSessionUuid(), request.getPageToken());
 		int limit = RecordUtil.getPageSize(request.getPageSize());
-		int offset = (pageNumber - 1) * RecordUtil.getPageSize(request.getPageSize());
+		int offset = (pageNumber - 1) * limit;
+
 		//	Add Row Number
 		parsedSQL = RecordUtil.getQueryWithLimit(parsedSQL, limit, offset);
 		//	Add Order By


### PR DESCRIPTION
#### Request
```bash
curl --location --request POST 'http://localhost:8085/api/adempiere/user-interface/smart-browser/browser-items?page_token=f266454d-53cc-45a4-9b6a-557796684dff-1&page_size=15&token=f266454d-53cc-45a4-9b6a-557796684dff&language=es&ts=1676060941965' \
--header 'Content-Type: application/json' \
--data-raw '{
    "uuid": "8aaeeea2-fb40-11e8-a479-7a0060f0aa01",
    "filters": [
        {
            "column_name": "CF_CreateFromType",
            "value": "O"
        },
        {
            "column_name": "CF_IsSameWarehouse",
            "value": false
        },
        {
            "column_name": "CF_C_Order_ID",
            "value": 1000007
        }
    ],
    "context_attributes": []
}'
```


#### Response

Before this changes
```json
{
    "code": 200,
    "result": {
        "record_count": 3,
        "next_page_token": "",
        "records": [
            ...
        ]
    }
}
```

After this changes
```json
{
    "code": 200,
    "result": {
        "record_count": 0,
        "next_page_token": "",
        "records": []
    }
}
```


#### Scrennshot

https://user-images.githubusercontent.com/20288327/218192718-1d046772-b177-455e-88d2-ebdde6696ede.mp4


#### Additional context
fixes https://github.com/solop-develop/frontend-core/issues/854



