### PR TITLE
fix: Document statuses/actions without isSOTrx column.

### DIFF
--- a/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/WorkflowServiceImplementation.java
@@ -334,9 +334,11 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 					orderType = documentType.getDocBaseType();
 				}
 			}
-			isSOTrx = ValueUtil.booleanToString(
-				entity.get_ValueAsBoolean(I_C_Order.COLUMNNAME_IsSOTrx)
-			);
+			if (entity.get_ColumnIndex(I_C_Order.COLUMNNAME_IsSOTrx) >= 0) {
+				isSOTrx = ValueUtil.booleanToString(
+					entity.get_ValueAsBoolean(I_C_Order.COLUMNNAME_IsSOTrx)
+				);
+			}
 			recordId = entity.get_ID();
 		}
 		if (documentStatus == null) {
@@ -583,7 +585,14 @@ public class WorkflowServiceImplementation extends WorkflowImplBase {
 				orderType = documentType.getDocBaseType();
 			}
 		}
-		String isSOTrx = entity.get_ValueAsBoolean(I_C_Order.COLUMNNAME_IsSOTrx)? "Y": "N";
+
+		String isSOTrx = "Y";
+		if (entity.get_ColumnIndex(I_C_Order.COLUMNNAME_IsSOTrx) >= 0) {
+			isSOTrx = ValueUtil.booleanToString(
+				entity.get_ValueAsBoolean(I_C_Order.COLUMNNAME_IsSOTrx)
+			);
+		}
+
 		//	
 		if (documentStatus == null) {
 			throw new AdempiereException("@DocStatus@ @NotFound@");


### PR DESCRIPTION

### Document Statuses

#### Request 
http://localhost:8085/api/adempiere/workflow/document-statuses?uuid=0e824f4a-b186-48c7-b51e-5cb821e281da&table_name=M_Requisition&page_token=&page_size=0&token=e440e31d-66dd-46f6-982e-6d74a8d91b79&language=es&ts=1677780160829

#### Log Warining
```log
-----------> MRequisition.get_Value: Column not found - IsSOTrx [153]
```

### Document Actions

#### Request
http://localhost:8085/api/adempiere/workflow/document-actions?uuid=0e824f4a-b186-48c7-b51e-5cb821e281da&table_name=M_Requisition&page_token=&page_size=0&token=e440e31d-66dd-46f6-982e-6d74a8d91b79&language=es&ts=1677780160828


#### Log Warining
```
-----------> MRequisition.get_Value: Column not found - IsSOTrx [159]
```
