### PR TITLE
fix: Login request without bearer token.

### DIFF
--- a/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
+++ b/src/main/java/org/spin/grpc/service/AccessServiceImplementation.java
@@ -538,18 +538,18 @@ public class AccessServiceImplementation extends SecurityImplBase {
 	 * @return
 	 */
 	private Session.Builder logoutSession(LogoutRequest request) {
-		Session.Builder builder = Session.newBuilder();
+		Properties context = ContextManager.getContext(request.getSessionUuid(), request.getLanguage());
 		//	Get Session
-		if(Util.isEmpty(request.getSessionUuid())) {
+		if (Util.isEmpty(request.getSessionUuid(), true)) {
 			throw new AdempiereException("@AD_Session_ID@ @NotFound@");
 		}
-		Properties context = Env.getCtx();
 		MSession session = getSessionFromUUid(request.getSessionUuid());
 		//	Logout
 		session.logout();
 		ContextManager.removeSession(session.getUUID());
 
 		//	Session values
+		Session.Builder builder = Session.newBuilder();
 		builder.setId(session.getAD_Session_ID());
 		builder.setUuid(ValueUtil.validateNull(session.getUUID()));
 		builder.setName(ValueUtil.validateNull(session.getDescription()));
@@ -557,7 +557,7 @@ public class AccessServiceImplementation extends SecurityImplBase {
 		//	Return session
 		return builder;
 	}
-	
+
 	/**
 	 * Logout session
 	 * @param request

--- a/src/main/java/org/spin/server/AllInOneServices.java
+++ b/src/main/java/org/spin/server/AllInOneServices.java
@@ -1,5 +1,5 @@
 /************************************************************************************
- * Copyright (C) 2012-2018 E.R.P. Consultores y Asociados, C.A.                     *
+ * Copyright (C) 2012-2023 E.R.P. Consultores y Asociados, C.A.                     *
  * Contributor(s): Yamel Senih ysenih@erpya.com                                     *
  * This program is free software: you can redistribute it and/or modify             *
  * it under the terms of the GNU General Public License as published by             *
@@ -82,8 +82,10 @@ public class AllInOneServices {
 		} else {
 			serverBuilder = ServerBuilder.forPort(SetupLoader.getInstance().getServer().getPort());
 		}
-		//	
-//		serverBuilder.intercept(new AuthorizationServerInterceptor());
+
+		// Validate JWT on all requests
+		serverBuilder.intercept(new AuthorizationServerInterceptor());
+
 		//	For Access
 		if(SetupLoader.getInstance().getServer().isValidService(Services.ACCESS.getServiceName())) {
 			serverBuilder.addService(new AccessServiceImplementation());


### PR DESCRIPTION
The login does not send a token, because at that point it has not yet been generated, however it was validated if the Bearer Token was empty and had a correct format.

The same applies for most of the `enrollment` services.

